### PR TITLE
fix: support Soped storage on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -151,7 +151,7 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.android.support:multidex:1.0.3'
-  implementation "com.squareup.okhttp3:okhttp:4.7.2"
+  implementation "com.squareup.okhttp3:okhttp:3.14.9"
   testImplementation 'androidx.test:core:1.3.0'
   testImplementation 'junit:junit:4.13.1'
   testImplementation "io.mockk:mockk:1.10.2"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,9 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+  }
 }
 
 repositories {
@@ -144,6 +147,7 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.android.support:multidex:1.0.3'
+  implementation "com.squareup.okhttp3:okhttp:4.7.2"
   testImplementation 'androidx.test:core:1.3.0'
   testImplementation 'junit:junit:4.13.1'
   testImplementation "io.mockk:mockk:1.10.2"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,10 @@ buildscript {
   }
 }
 
+plugins {
+  id "com.adarshr.test-logger" version "2.1.1"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.0'
+    classpath 'com.android.tools.build:gradle:4.1.1'
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-BlobCourier_kotlinVersion = 1.4.10
+BlobCourier_kotlinVersion = 1.4.21
 BlobCourier_compileSdkVersion = 30
 BlobCourier_buildToolsVersion = 30.0.0
 BlobCourier_targetSdkVersion = 29

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
-BlobCourier_kotlinVersion=1.4.10
-BlobCourier_compileSdkVersion=30
-BlobCourier_buildToolsVersion=30.0.0
-BlobCourier_targetSdkVersion=29
+BlobCourier_kotlinVersion = 1.4.10
+BlobCourier_compileSdkVersion = 30
+BlobCourier_buildToolsVersion = 30.0.0
+BlobCourier_targetSdkVersion = 29
 
-android.useAndroidX=true
+android.useAndroidX = true

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,5 @@
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
 </manifest>

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -451,7 +451,7 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
             mapOf(
               "type" to DOWNLOAD_TYPE_UNMANAGED,
               "data" to mapOf(
-                "absoluteFilePath" to absoluteFilePath,
+                "absoluteFilePath" to Uri.fromFile(absoluteFilePath),
                 "response" to mapOf(
                   "code" to response.code,
                   "headers" to mapHeadersToMap(response.headers)

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -211,6 +211,9 @@ private fun startBlobUpload(
           val payload = this.getMap(PARAMETER_PART_PAYLOAD)!!
 
           val fileUrl = Uri.parse(payload.getString(PARAMETER_ABSOLUTE_FILE_PATH)!!)
+          val fileUrlWithScheme =
+            if (fileUrl.scheme == null) Uri.parse("file://$fileUrl") else fileUrl
+
           val filename =
             if (payload.hasKey(PARAMETER_FILENAME)) (
               payload.getString(PARAMETER_FILENAME)
@@ -223,7 +226,7 @@ private fun startBlobUpload(
             InputStreamRequestBody(
               payload.getString(PARAMETER_MIME_TYPE)?.toMediaTypeOrNull()!!, // FIXME Use fallback
               reactContext.contentResolver,
-              fileUrl
+              fileUrlWithScheme
             )
           )
         }

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -63,7 +63,7 @@ private val REQUIRED_PARAMETER_PROCESSORS = ImmutableMap.of(
 
 private val AVAILABLE_PARAMETER_PROCESSORS = REQUIRED_PARAMETER_PROCESSORS.keys.joinToString(", ")
 
-private val DEFAULT_OK_HTTP_CLIENT = OkHttpClientProvider.getOkHttpClient()
+private fun createHttpClient() = OkHttpClientProvider.getOkHttpClient()
 
 private fun processUnexpectedError(promise: Promise, e: Error) = promise.reject(
   ERROR_UNEXPECTED_ERROR,
@@ -256,7 +256,7 @@ private fun startBlobUpload(
 
   thread {
     try {
-      val response = DEFAULT_OK_HTTP_CLIENT.newCall(
+      val response = createHttpClient().newCall(
         requestBuilder
       ).execute()
 
@@ -433,7 +433,7 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
       .build()
 
     val httpClient =
-      DEFAULT_OK_HTTP_CLIENT.newBuilder()
+      createHttpClient().newBuilder()
         .addInterceptor(createDownloadProgressInterceptor(reactContext, taskId, progressInterval))
         .build()
 

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressRequest.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressRequest.kt
@@ -13,8 +13,8 @@ import okhttp3.RequestBody
 import okio.Buffer
 import okio.BufferedSink
 import okio.ForwardingSink
+import okio.Okio
 import okio.Sink
-import okio.buffer
 
 class BlobCourierProgressRequest(
   private val context: ReactApplicationContext,
@@ -30,7 +30,7 @@ class BlobCourierProgressRequest(
 
   @Throws(IOException::class)
   override fun writeTo(sink: BufferedSink) =
-    CountingSink(sink).buffer().use(requestBody::writeTo)
+    Okio.buffer(CountingSink(sink)).use(requestBody::writeTo)
 
   private inner class CountingSink(delegate: Sink) : ForwardingSink(delegate) {
     private val progressNotifier =

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressRequest.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressRequest.kt
@@ -13,8 +13,8 @@ import okhttp3.RequestBody
 import okio.Buffer
 import okio.BufferedSink
 import okio.ForwardingSink
-import okio.Okio
 import okio.Sink
+import okio.buffer
 
 class BlobCourierProgressRequest(
   private val context: ReactApplicationContext,
@@ -30,7 +30,7 @@ class BlobCourierProgressRequest(
 
   @Throws(IOException::class)
   override fun writeTo(sink: BufferedSink) =
-    Okio.buffer(CountingSink(sink)).use(requestBody::writeTo)
+    CountingSink(sink).buffer().use(requestBody::writeTo)
 
   private inner class CountingSink(delegate: Sink) : ForwardingSink(delegate) {
     private val progressNotifier =

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressResponse.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressResponse.kt
@@ -12,9 +12,9 @@ import okhttp3.MediaType
 import okhttp3.ResponseBody
 import okio.Buffer
 import okio.BufferedSource
+import okio.Okio
 import okio.Source
 import okio.Timeout
-import okio.buffer
 
 class BlobCourierProgressResponse(
   private val context: ReactApplicationContext,
@@ -29,7 +29,7 @@ class BlobCourierProgressResponse(
   override fun contentLength(): Long = responseBody.contentLength()
 
   override fun source(): BufferedSource =
-    ProgressReportingSource().buffer()
+    Okio.buffer(ProgressReportingSource())
 
   private inner class ProgressReportingSource : Source {
     private var totalNumberOfBytesRead: Long = 0

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressResponse.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierProgressResponse.kt
@@ -12,9 +12,9 @@ import okhttp3.MediaType
 import okhttp3.ResponseBody
 import okio.Buffer
 import okio.BufferedSource
-import okio.Okio
 import okio.Source
 import okio.Timeout
+import okio.buffer
 
 class BlobCourierProgressResponse(
   private val context: ReactApplicationContext,
@@ -29,7 +29,7 @@ class BlobCourierProgressResponse(
   override fun contentLength(): Long = responseBody.contentLength()
 
   override fun source(): BufferedSource =
-    Okio.buffer(ProgressReportingSource())
+    ProgressReportingSource().buffer()
 
   private inner class ProgressReportingSource : Source {
     private var totalNumberOfBytesRead: Long = 0
@@ -52,7 +52,7 @@ class BlobCourierProgressResponse(
       return numberOfBytesRead
     }
 
-    override fun timeout(): Timeout? = Timeout.NONE
+    override fun timeout(): Timeout = Timeout.NONE
 
     @Throws(IOException::class)
     override fun close() = Unit

--- a/android/src/main/java/io/deckers/blob_courier/InputStreamRequestBody.kt
+++ b/android/src/main/java/io/deckers/blob_courier/InputStreamRequestBody.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 import okhttp3.MediaType
 import okhttp3.RequestBody
 import okio.BufferedSink
-import okio.source
+import okio.Okio
 
 // Credit:
 // [1] https://commonsware.com/blog/2020/07/05/multipart-upload-okttp-uri.html
@@ -30,7 +30,7 @@ class InputStreamRequestBody(
   override fun writeTo(sink: BufferedSink) {
     val input = contentResolver.openInputStream(uri)
 
-    input?.use { sink.writeAll(it.source()) }
+    input?.use { sink.writeAll(Okio.source(it)) }
       ?: throw IOException("Could not open $uri")
   }
 }

--- a/android/src/main/java/io/deckers/blob_courier/InputStreamRequestBody.kt
+++ b/android/src/main/java/io/deckers/blob_courier/InputStreamRequestBody.kt
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Ely Deckers.
+ *
+ * This source code is licensed under the MPL-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package io.deckers.blob_courier
+
+import android.content.ContentResolver
+import android.net.Uri
+import java.io.IOException
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.source
+
+// Credit:
+// [1] https://commonsware.com/blog/2020/07/05/multipart-upload-okttp-uri.html
+// [2] https://github.com/square/okhttp/issues/3585#issuecomment-327319196
+class InputStreamRequestBody(
+  private val contentType: MediaType,
+  private val contentResolver: ContentResolver,
+  private val uri: Uri
+) : RequestBody() {
+  override fun contentType() = contentType
+
+  override fun contentLength(): Long = -1
+
+  @Throws(IOException::class)
+  override fun writeTo(sink: BufferedSink) {
+    val input = contentResolver.openInputStream(uri)
+
+    input?.use { sink.writeAll(it.source()) }
+      ?: throw IOException("Could not open $uri")
+  }
+}

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -6,6 +6,7 @@
  */
 package io.deckers.blob_courier
 
+import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.JavaOnlyMap
@@ -25,6 +26,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 
 private fun retrieveMissingKeys(
@@ -208,6 +210,9 @@ class BlobCourierModuleTests {
               val taskId = allRequiredParametersMap.getString("taskId") ?: ""
               val absoluteFilePath = r0?.getMap("data")?.getString("absoluteFilePath") ?: ""
 
+              Shadows.shadowOf(ctx.contentResolver)
+                .registerInputStream(Uri.parse(absoluteFilePath), "".byteInputStream())
+
               val uploadParametersMap =
                 createValidUploadTestParameterMap(taskId, absoluteFilePath).toReactMap()
 
@@ -359,6 +364,9 @@ class BlobCourierModuleTests {
             { r0 ->
               val taskId = allFetchParametersMap["taskId"] ?: ""
               val absoluteFilePath = r0?.getMap("data")?.getString("absoluteFilePath") ?: ""
+
+              Shadows.shadowOf(ctx.contentResolver)
+                .registerInputStream(Uri.parse(absoluteFilePath), "".byteInputStream())
 
               val uploadParametersMap =
                 createValidUploadTestParameterMap(taskId, absoluteFilePath).toReactMap()

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -111,7 +111,8 @@ class BlobCourierModuleTests {
     pool.execute {
       synchronized(threadLock) {
         runFetchBlob(
-          ctx, allRequiredParametersMap,
+          ctx,
+          allRequiredParametersMap,
           Fixtures.EitherPromise(
             { m0 -> finishThread(false, "Failed fetch: $m0") },
             { finishThread(true, "Success") }
@@ -123,6 +124,7 @@ class BlobCourierModuleTests {
 
     pool.shutdown()
 
+    println("result=$result")
     if (!pool.awaitTermination(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS * 1L, TimeUnit.MILLISECONDS)) {
       pool.shutdownNow()
       assertTrue(

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -91,7 +91,7 @@ class BlobCourierModuleTests {
     }
   }
 
-  @Test
+  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun all_required_fetch_parameters_provided_resolves_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -125,7 +125,6 @@ class BlobCourierModuleTests {
 
     pool.shutdown()
 
-    println("result=$result")
     if (!pool.awaitTermination(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS * 1L, TimeUnit.MILLISECONDS)) {
       pool.shutdownNow()
       assertTrue(
@@ -137,7 +136,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
-  @Test
+  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun unreachable_fetch_server_rejects_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
     val requestWithNonExistentUrl =
@@ -184,7 +183,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
-  @Test
+  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun all_required_parameters_provided_resolves_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -247,7 +246,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
-  @Test
+  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun unreachable_server_rejects_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -320,7 +319,7 @@ class BlobCourierModuleTests {
     }
   }
 
-  @Test
+  @Test // This is the faster, and less thorough version of the Instrumented test with the same name
   fun uploading_a_file_from_outside_app_data_directory_resolves_promise() {
     val someFileThatIsAlwaysAvailable = "file:///system/etc/fonts.xml"
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.2")
+        classpath("com.android.tools.build:gradle:3.5.4")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
As described in #67 

**Progress**
- [x] Use `ContentResolver`
- [x] Verify on Android 9
- [x] Verify on Android 10
- [x] Verify on Android 11
- [x] Resolve CI crash failure due to upgrade of OkHttp from 3.x to 4.x
- [x] Add Android unit test
- [x] Add Android instrumented test