### PR TITLE
fix: multipart fields arrive in unpredictable order

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,48 @@ console.log(fetchedResult);
 // }
 ```
 
+## Multipart upload
+
+Sometimes order of multipart fields matters, and Blob Courier respects the order in which parts are provided. There is a catch though: when object keys are regular strings they are kept in the order they were added _unless_ the keys are strings containing numbers, e.g.:
+
+```tsx
+Object.keys({
+  "b": "some_value1",
+  "c": "some_value2",
+  "a": "some_value3",
+})
+
+// ['b', 'c', 'a']
+
+Object.keys({
+  "b": "some_value1",
+  "c": "some_value2",
+  "a": "some_value3",
+  "3": "some_value4",
+  "2": "some_value5",
+  "1": "some_value6",
+});
+
+// ['1', '2', '3', 'b', 'c', 'a']
+```
+
+The way to work around this, is to wrap _all_ keys in a `Symbol`, by using `Symbol.for`. Do not use `Symbol(<value>)`, this will not work, e.g.:
+
+```tsx
+Object.getOwnPropertySymbols({
+  [Symbol.for("b")]: "some_value1",
+  [Symbol.for("c")]: "some_value2",
+  [Symbol.for("a")]: "some_value3",
+  [Symbol.for("3")]: "some_value4",
+  [Symbol.for("2")]: "some_value5",
+  [Symbol.for("1")]: "some_value6",
+});
+
+// [Symbol('b'), Symbol('c'), Symbol('a'), Symbol('3'), Symbol('2'), Symbol('1')]
+
+```
+
+
 ## Fluent interface
 
 Blob Courier provides a fluent interface, that both protects you from using impossible setting combinations and arguably improves readability.

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -7,6 +7,7 @@
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import io.deckers.blob_courier.DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
@@ -48,6 +49,7 @@ class BlobCourierInstrumentedModuleTests {
     mockkStatic(Arguments::class)
 
     every { Arguments.createMap() } answers { JavaOnlyMap() }
+    every { Arguments.createArray() } answers { JavaOnlyArray() }
   }
 
   @Test

--- a/android/src/main/java/io/deckers/blob_courier/common/Parameters.kt
+++ b/android/src/main/java/io/deckers/blob_courier/common/Parameters.kt
@@ -8,6 +8,7 @@ package io.deckers.blob_courier.common
 
 import com.facebook.common.internal.ImmutableMap
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import java.lang.reflect.Type
 
@@ -18,16 +19,16 @@ const val PARAMETER_FILENAME = "filename"
 const val PARAMETER_HEADERS = "headers"
 const val PARAMETER_METHOD = "method"
 const val PARAMETER_MIME_TYPE = "mimeType"
+const val PARAMETER_PART_NAME = "name"
 const val PARAMETER_PART_PAYLOAD = "payload"
+const val PARAMETER_PART_TYPE = "type"
 const val PARAMETER_SETTINGS_PROGRESS_INTERVAL = "progressIntervalMilliseconds"
 const val PARAMETER_TASK_ID = "taskId"
 const val PARAMETER_URL = "url"
 
 private val REQUIRED_PARAMETER_PROCESSORS = ImmutableMap.of(
-  Boolean::class.java.toString(),
-  { input: ReadableMap, parameterName: String -> input.getBoolean(parameterName) },
-  ReadableMap::class.java.toString(),
-  { input: ReadableMap, parameterName: String -> input.getMap(parameterName) },
+  Array::class.java.toString(),
+  { input: ReadableMap, parameterName: String -> input.getArray(parameterName) },
   String::class.java.toString(),
   { input: ReadableMap, parameterName: String -> input.getString(parameterName) }
 )
@@ -50,16 +51,10 @@ fun assertRequiredParameter(input: ReadableMap, type: Type, parameterName: Strin
   )
 }
 
-fun tryRetrieveBoolean(input: ReadableMap, parameterName: String): Boolean {
-  assertRequiredParameter(input, Boolean::class.java, parameterName)
+fun tryRetrieveArray(input: ReadableMap, parameterName: String): ReadableArray? {
+  assertRequiredParameter(input, Array::class.java, parameterName)
 
-  return input.getBoolean(parameterName)
-}
-
-fun tryRetrieveMap(input: ReadableMap, parameterName: String): ReadableMap? {
-  assertRequiredParameter(input, ReadableMap::class.java, parameterName)
-
-  return input.getMap(parameterName)
+  return input.getArray(parameterName)
 }
 
 fun tryRetrieveString(input: ReadableMap, parameterName: String): String? {

--- a/android/src/main/java/io/deckers/blob_courier/common/Utils.kt
+++ b/android/src/main/java/io/deckers/blob_courier/common/Utils.kt
@@ -10,6 +10,7 @@ import android.app.DownloadManager
 import android.content.Context
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import okhttp3.Headers
@@ -38,12 +39,36 @@ fun notifyBridgeOfProgress(
 fun createDownloadManager(context: Context) =
   context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
 
+fun Array<*>.toReactArray(): WritableArray {
+  val thisMap = this
+
+  return Arguments.createArray().apply {
+    thisMap.forEach { v ->
+      when {
+        (v is Array<*>) -> {
+          pushArray(v.toReactArray())
+        }
+        (v is String) ->
+          pushString(v)
+        (v is Map<*, *>) -> {
+          pushMap(v.toReactMap())
+        }
+        else ->
+          pushString(v.toString())
+      }
+    }
+  }
+}
+
 fun Map<*, *>.toReactMap(): WritableMap {
   val thisMap = this
 
   return Arguments.createMap().apply {
     thisMap.forEach { (k, v) ->
       when {
+        (v is Array<*>) -> {
+          putArray(k.toString(), v.toReactArray())
+        }
         (v is String) ->
           putString(k.toString(), v)
         (v is Map<*, *>) -> {

--- a/android/src/main/java/io/deckers/blob_courier/upload/BlobUploader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/BlobUploader.kt
@@ -31,13 +31,13 @@ class BlobUploader(
     val mpb = MultipartBody.Builder()
       .setType(MultipartBody.FORM)
 
-    uploaderParameters.parts.keys.forEach { multipartName ->
-      if (uploaderParameters.parts[multipartName]?.payload is FilePart) {
-        val payload = uploaderParameters.parts[multipartName]?.payload as FilePart
+    uploaderParameters.parts.forEach { part ->
+      if (part.payload is FilePart) {
+        val payload = part.payload
 
         payload.run {
           mpb.addFormDataPart(
-            multipartName,
+            part.name,
             payload.filename,
             InputStreamRequestBody(
               payload.mimeType.let { MediaType.parse(it) }
@@ -49,14 +49,11 @@ class BlobUploader(
         }
       }
 
-      if (uploaderParameters.parts[multipartName]?.payload is DataPart) {
-        val payload = uploaderParameters.parts[multipartName]?.payload as DataPart
+      if (part.payload is DataPart) {
+        val payload = part.payload
 
         payload.run {
-          mpb.addFormDataPart(
-            multipartName,
-            payload.value
-          )
+          mpb.addFormDataPart(part.name, payload.value)
         }
       }
     }

--- a/android/src/main/java/io/deckers/blob_courier/upload/BlobUploader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/BlobUploader.kt
@@ -8,14 +8,11 @@ package io.deckers.blob_courier.upload
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import io.deckers.blob_courier.common.DEFAULT_MIME_TYPE
 import io.deckers.blob_courier.common.ERROR_UNEXPECTED_ERROR
 import io.deckers.blob_courier.common.ERROR_UNEXPECTED_EXCEPTION
 import io.deckers.blob_courier.common.mapHeadersToMap
 import io.deckers.blob_courier.common.toReactMap
 import io.deckers.blob_courier.progress.BlobCourierProgressRequest
-import okhttp3.MediaType
-import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -28,42 +25,11 @@ class BlobUploader(
     uploaderParameters: UploaderParameters,
     promise: Promise,
   ) {
-    val mpb = MultipartBody.Builder()
-      .setType(MultipartBody.FORM)
-
-    uploaderParameters.parts.forEach { part ->
-      if (part.payload is FilePart) {
-        val payload = part.payload
-
-        payload.run {
-          mpb.addFormDataPart(
-            part.name,
-            payload.filename,
-            InputStreamRequestBody(
-              payload.mimeType.let { MediaType.parse(it) }
-                ?: MediaType.get(DEFAULT_MIME_TYPE),
-              reactContext.contentResolver,
-              payload.absoluteFilePath
-            )
-          )
-        }
-      }
-
-      if (part.payload is DataPart) {
-        val payload = part.payload
-
-        payload.run {
-          mpb.addFormDataPart(part.name, payload.value)
-        }
-      }
-    }
-
-    val multipartBody = mpb.build()
 
     val requestBody = BlobCourierProgressRequest(
       reactContext,
       uploaderParameters.taskId,
-      multipartBody,
+      uploaderParameters.toMultipartBody(reactContext.contentResolver),
       uploaderParameters.progressInterval
     )
 

--- a/android/src/main/java/io/deckers/blob_courier/upload/Part.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/Part.kt
@@ -6,4 +6,4 @@
  */
 package io.deckers.blob_courier.upload
 
-data class Part(val payload: PartPayload)
+data class Part(val name: String, val payload: PartPayload)

--- a/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
@@ -8,89 +8,95 @@ package io.deckers.blob_courier.upload
 
 import android.net.Uri
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
 import io.deckers.blob_courier.common.DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS
 import io.deckers.blob_courier.common.DEFAULT_UPLOAD_METHOD
+import io.deckers.blob_courier.common.ERROR_INVALID_VALUE
 import io.deckers.blob_courier.common.ERROR_MISSING_REQUIRED_PARAMETER
+import io.deckers.blob_courier.common.ERROR_UNEXPECTED_EMPTY_VALUE
 import io.deckers.blob_courier.common.PARAMETER_ABSOLUTE_FILE_PATH
 import io.deckers.blob_courier.common.PARAMETER_FILENAME
 import io.deckers.blob_courier.common.PARAMETER_HEADERS
 import io.deckers.blob_courier.common.PARAMETER_METHOD
 import io.deckers.blob_courier.common.PARAMETER_MIME_TYPE
+import io.deckers.blob_courier.common.PARAMETER_PART_NAME
 import io.deckers.blob_courier.common.PARAMETER_PART_PAYLOAD
+import io.deckers.blob_courier.common.PARAMETER_PART_TYPE
 import io.deckers.blob_courier.common.PARAMETER_SETTINGS_PROGRESS_INTERVAL
 import io.deckers.blob_courier.common.PARAMETER_TASK_ID
 import io.deckers.blob_courier.common.PARAMETER_URL
 import io.deckers.blob_courier.common.filterHeaders
 import io.deckers.blob_courier.common.getMapInt
 import io.deckers.blob_courier.common.processUnexpectedEmptyValue
-import io.deckers.blob_courier.common.tryRetrieveMap
+import io.deckers.blob_courier.common.tryRetrieveArray
 import io.deckers.blob_courier.common.tryRetrieveString
 import java.net.URL
 
 private const val PARAMETER_PARTS = "parts"
 private const val PARAMETER_RETURN_RESPONSE = "returnResponse"
 
-private fun verifyFilePart(part: ReadableMap, promise: Promise): Boolean {
+private fun verifyFilePart(part: ReadableMap): Triple<Boolean, String, String> {
   if (!part.hasKey(PARAMETER_PART_PAYLOAD)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
-    return false
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
   }
 
   val payload = part.getMap(PARAMETER_PART_PAYLOAD)!!
   if (!payload.hasKey(PARAMETER_ABSOLUTE_FILE_PATH)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_ABSOLUTE_FILE_PATH")
-    return false
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_ABSOLUTE_FILE_PATH")
   }
 
   if (!payload.hasKey(PARAMETER_MIME_TYPE)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_MIME_TYPE")
-    return false
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_MIME_TYPE")
   }
 
   if (payload.getString(PARAMETER_ABSOLUTE_FILE_PATH).isNullOrEmpty()) {
-    processUnexpectedEmptyValue(promise, PARAMETER_ABSOLUTE_FILE_PATH)
-    return false
+    return Triple(false, ERROR_UNEXPECTED_EMPTY_VALUE, "part.$PARAMETER_ABSOLUTE_FILE_PATH")
   }
 
   if (payload.getString(PARAMETER_MIME_TYPE).isNullOrEmpty()) {
-    processUnexpectedEmptyValue(promise, PARAMETER_MIME_TYPE)
-    return false
+    return Triple(false, ERROR_UNEXPECTED_EMPTY_VALUE, "part.$PARAMETER_MIME_TYPE")
   }
 
-  return true
+  return Triple(true, "", "")
 }
 
-private fun verifyStringPart(part: ReadableMap, promise: Promise): Boolean {
+private fun verifyStringPart(part: ReadableMap): Triple<Boolean, String, String> {
   if (part.hasKey(PARAMETER_PART_PAYLOAD)) {
-    return true
+    return Triple(true, "", "")
   }
 
-  promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
-  return false
+  return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
 }
 
-private fun verifyPart(part: ReadableMap?, promise: Promise): Boolean {
+private fun verifyPart(part: ReadableMap?): Triple<Boolean, String, String> {
   if (part == null) {
-    processUnexpectedEmptyValue(promise, "part")
-    return false
+    return Triple(false, ERROR_UNEXPECTED_EMPTY_VALUE, "part")
   }
 
-  if (!part.hasKey("type")) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.type")
-    return false
+  if (!part.hasKey(PARAMETER_PART_NAME)) {
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_NAME")
   }
 
-  if (part.getString("type") == "file") {
-    return verifyFilePart(part, promise)
+  if (!part.hasKey(PARAMETER_PART_PAYLOAD)) {
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
   }
 
-  return verifyStringPart(part, promise)
+  if (!part.hasKey(PARAMETER_PART_TYPE)) {
+    return Triple(false, ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_TYPE")
+  }
+
+  if (part.getString(PARAMETER_PART_TYPE) == "file") {
+    return verifyFilePart(part)
+  }
+
+  return verifyStringPart(part)
 }
 
 data class UploaderParameters(
   val taskId: String,
-  val parts: Map<String, Part>,
+  val parts: List<Part>,
   val uri: URL,
   val method: String,
   val headers: Map<String, String>,
@@ -98,29 +104,37 @@ data class UploaderParameters(
   val progressInterval: Int
 )
 
-private fun createFilePayload(payload: ReadableMap, promise: Promise): FilePart? {
-  if (!payload.hasKey(PARAMETER_ABSOLUTE_FILE_PATH)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "payload.$PARAMETER_ABSOLUTE_FILE_PATH")
-    return null
+private fun filterReadableMapsFromReadableArray(parts: ReadableArray): Array<ReadableMap> =
+  (0 until parts.size()).fold(
+    emptyArray(),
+    { p, i ->
+      if (parts.getType(i) == ReadableType.Map)
+        p.plus(parts.getMap(i)!!)
+      else p
+    }
+  )
+
+private fun verifyParts(parts: ReadableArray, promise: Promise): Boolean {
+  val mapParts = filterReadableMapsFromReadableArray(parts)
+
+  val diff = parts.size() - mapParts.size
+  if (diff > 0) {
+    promise.reject(ERROR_INVALID_VALUE, "$diff provided part(s) are not ReadableMap objects")
+    return false
   }
 
-  if (!payload.hasKey(PARAMETER_MIME_TYPE)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "payload.$PARAMETER_MIME_TYPE")
-    return null
+  val failedPartVerifications =
+    mapParts.map(::verifyPart).filter { verification -> !verification.first }
+  if (failedPartVerifications.isNotEmpty()) {
+    val firstFailure = failedPartVerifications.first()
+    promise.reject(firstFailure.second, firstFailure.third)
+    return false
   }
 
-  val absoluteFilePath = payload.getString(PARAMETER_ABSOLUTE_FILE_PATH)
-  if (absoluteFilePath.isNullOrEmpty()) {
-    processUnexpectedEmptyValue(promise, PARAMETER_ABSOLUTE_FILE_PATH)
-    return null
-  }
+  return true
+}
 
-  val mimeType = payload.getString(PARAMETER_MIME_TYPE)
-  if (mimeType.isNullOrEmpty()) {
-    processUnexpectedEmptyValue(promise, PARAMETER_MIME_TYPE)
-    return null
-  }
-
+private fun createFilePayload(payload: ReadableMap): FilePart? {
   val fileUrl = Uri.parse(payload.getString(PARAMETER_ABSOLUTE_FILE_PATH)!!)
   val fileUrlWithScheme =
     if (fileUrl.scheme == null) Uri.parse("file://$fileUrl") else fileUrl
@@ -130,6 +144,7 @@ private fun createFilePayload(payload: ReadableMap, promise: Promise): FilePart?
       payload.getString(PARAMETER_FILENAME)
         ?: fileUrl.lastPathSegment
       ) else fileUrl.lastPathSegment
+  val mimeType = payload.getString(PARAMETER_MIME_TYPE)!!
 
   if (fileUrlWithScheme == null) {
     return null
@@ -142,39 +157,23 @@ private fun createFilePayload(payload: ReadableMap, promise: Promise): FilePart?
   return FilePart(fileUrlWithScheme, filename, mimeType)
 }
 
-private fun createPart(part: ReadableMap, promise: Promise): Part? {
-  if (!verifyPart(part, promise)) {
-    return null
-  }
+private fun createPart(part: ReadableMap): Part {
+  val name = part.getString(PARAMETER_PART_NAME)!!
 
-  if (!part.hasKey(PARAMETER_PART_PAYLOAD)) {
-    promise.reject(ERROR_MISSING_REQUIRED_PARAMETER, "part.$PARAMETER_PART_PAYLOAD")
-    return null
-  }
-
-  val maybePayload = when (part.getString("type")) {
-    "file" -> part.getMap(PARAMETER_PART_PAYLOAD)?.let { createFilePayload(it, promise) }
+  val payload = when (part.getString(PARAMETER_PART_TYPE)) {
+    "file" -> part.getMap(PARAMETER_PART_PAYLOAD)?.let(::createFilePayload)
     else -> DataPart(part.getString(PARAMETER_PART_PAYLOAD) ?: "")
-  }
+  }!!
 
-  return maybePayload?.let { it -> Part(it) }
+  return Part(name, payload)
 }
 
-private fun createParts(maybeParts: ReadableMap, promise: Promise): Map<String, Part> =
-  maybeParts.toHashMap().keys.fold(
-    emptyMap(),
-    { p, multipartName ->
-      val maybePart = maybeParts.getMap(multipartName)
-
-      val px = maybePart?.let { createPart(maybePart, promise) }
-
-      px?.let { p.plus(multipartName to it) } ?: p
-    }
-  )
+private fun createParts(parts: ReadableArray): List<Part> =
+  filterReadableMapsFromReadableArray(parts).map(::createPart)
 
 private fun retrieveRequiredParametersOrThrow(input: ReadableMap):
-  Triple<ReadableMap?, String?, String?> {
-    val rawParts = tryRetrieveMap(input, PARAMETER_PARTS)
+  Triple<ReadableArray?, String?, String?> {
+    val rawParts = tryRetrieveArray(input, PARAMETER_PARTS)
     val taskId = tryRetrieveString(input, PARAMETER_TASK_ID)
     val url = tryRetrieveString(input, PARAMETER_URL)
 
@@ -182,9 +181,9 @@ private fun retrieveRequiredParametersOrThrow(input: ReadableMap):
   }
 
 private fun validateRequiredParameters(
-  parameters: Triple<ReadableMap?, String?, String?>,
+  parameters: Triple<ReadableArray?, String?, String?>,
   promise: Promise
-): Triple<ReadableMap, String, String>? {
+): Triple<ReadableArray, String, String>? {
   val (rawParts, taskId, url) = parameters
 
   if (taskId == null) {
@@ -232,7 +231,11 @@ class UploaderParameterFactory {
           DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS
         )
 
-      val parts = createParts(rawParts, promise)
+      if (!verifyParts(rawParts, promise)) {
+        return null
+      }
+
+      val parts = createParts(rawParts)
 
       val uri = URL(url)
 

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 
-const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 10_000L
+const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 50_000L
 
 object Fixtures {
 
@@ -24,10 +24,11 @@ object Fixtures {
   fun createValidUploadTestParameterMap(
     taskId: String,
     localPath: String
-  ): Map<String, Any> = mapOf(
-    "taskId" to taskId,
-    "parts" to mapOf(
-      "file" to mapOf(
+  ) = TestUploadParameterMap(
+    taskId,
+    arrayOf(
+      mapOf(
+        "name" to "file",
         "payload" to mapOf(
           "absoluteFilePath" to localPath,
           "mimeType" to "text/html"
@@ -35,7 +36,7 @@ object Fixtures {
         "type" to "file"
       )
     ),
-    "url" to "https://file.io"
+    "https://file.io"
   )
 
   fun runFetchBlob(

--- a/android/src/sharedTest/java/io/deckers/blob_courier/TestUploadParameterMap.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/TestUploadParameterMap.kt
@@ -1,0 +1,33 @@
+package io.deckers.blob_courier
+
+import io.deckers.blob_courier.common.toReactMap
+
+data class TestUploadParameterMap(
+  val taskId: String,
+  val parts: Array<Map<String, *>>,
+  val url: String
+) {
+
+  fun toMap() = mapOf("taskId" to taskId, "parts" to parts, "url" to url)
+  fun toReactMap() = toMap().toReactMap()
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as TestUploadParameterMap
+
+    if (taskId != other.taskId) return false
+    if (!parts.contentEquals(other.parts)) return false
+    if (url != other.url) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = taskId.hashCode()
+    result = 31 * result + parts.contentHashCode()
+    result = 31 * result + url.hashCode()
+    return result
+  }
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
   - React-jsinspector (0.62.2)
-  - react-native-blob-courier (1.0.0):
+  - react-native-blob-courier (1.0.4):
     - React
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -429,7 +429,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-blob-courier: f059c5a2da9547bde79fec322fea0342bf8579c8
+  react-native-blob-courier: d16f79db182a2cd71a38aeb427abe443201bccc6
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/ios/BlobCourier.swift
+++ b/ios/BlobCourier.swift
@@ -4,7 +4,6 @@
 //  LICENSE file in the root directory of this source tree.
 import Foundation
 
-// swiftlint:disable type_body_length
 @objc(BlobCourier)
 open class BlobCourier: NSObject {
   static let downloadTypeUnmanaged  = "Unmanaged"
@@ -144,7 +143,7 @@ open class BlobCourier: NSObject {
 
   func buildRequestDataForFileUpload(
     url: URL,
-    parts: NSDictionary,
+    parts: NSArray,
     headers: NSDictionary) throws -> (URLRequest, Data) {
     let boundary = UUID().uuidString
 
@@ -162,9 +161,9 @@ open class BlobCourier: NSObject {
 
     var data = Data()
 
-    var index = 0
-    for (key, value) in parts {
-      if let paramName = key as? String, let part = value as? [String: Any] {
+    for value in parts {
+      if let part = value as? [String: Any], let paramName = part["name"] as? String {
+
         if part["type"] as? String == "file" {
           let payload = part[BlobCourier.parameterPartPayload] as? [String: String] ?? [:]
           let absoluteFilePath = payload[BlobCourier.parameterAbsoluteFilePath]!
@@ -215,7 +214,7 @@ open class BlobCourier: NSObject {
 
     let urlObject = URL(string: url)!
 
-    let parts = (input[BlobCourier.parameterParts] as? NSDictionary) ?? NSDictionary()
+    let parts = (input[BlobCourier.parameterParts] as? NSArray) ?? NSArray()
 
     let returnResponse = (input[BlobCourier.parameterReturnResponse] as? Bool) ?? false
 
@@ -267,7 +266,7 @@ open class BlobCourier: NSObject {
   ) {
     do {
       try assertRequiredParameter(
-        input: input, type: "NSDictionary", parameterName: BlobCourier.parameterParts)
+        input: input, type: "NSArray", parameterName: BlobCourier.parameterParts)
       try assertRequiredParameter(
         input: input, type: "String", parameterName: BlobCourier.parameterTaskId)
       try assertRequiredParameter(

--- a/ios/BlobCourierTests/BlobCourierTests.swift
+++ b/ios/BlobCourierTests/BlobCourierTests.swift
@@ -91,14 +91,16 @@ class BlobCourierTests: XCTestCase {
 
             self.sut?.uploadBlob(input: [
              "parts": [
-               "file": [
+               [
+                 "name": "file",
                  "payload": [
                     "absoluteFilePath": data["absoluteFilePath"] ?? "",
                     "mimeType": "image/png"
                  ],
                  "type": "file"
                ],
-               "test": [
+               [
+                 "name": "test",
                  "payload": "SOME_TEST_STRING",
                  "type": "string"
                ]
@@ -292,7 +294,8 @@ class BlobCourierTests: XCTestCase {
 
         self.sut?.uploadBlob(input: [
          "parts": [
-           "file": [
+           [
+             "name": "file",
              "payload": [
                 "absoluteFilePath": "/this/path/does/not/exist.png",
                 "mimeType": "image/png"

--- a/ios/BlobCourierTests/BlobCourierTests.swift
+++ b/ios/BlobCourierTests/BlobCourierTests.swift
@@ -37,7 +37,7 @@ class BlobCourierTests: XCTestCase {
           "url": "https://github.com/edeckers/react-native-blob-courier"
         ]
 
-        let expectedParts = ["file", "test"]
+        let expectedParts = ["test", "file"]
 
         let router = Router()
         router["/api/v2/users"] =
@@ -61,10 +61,12 @@ class BlobCourierTests: XCTestCase {
                       if let value = mime.header.contentDisposition?.parameters["name"] {
                         acc.append(value)
                       }
-                    }.sorted()
+                    }
 
-                    if actualParts != expectedParts {
+                    if actualParts.sorted() != expectedParts.sorted() {
                       result = (false, "Did not receive all expected parts")
+                    } else if actualParts != expectedParts {
+                      result = (false, "Received parts order differs from provided order")
                     } else {
                       result = (true, "Success")
                     }
@@ -92,17 +94,17 @@ class BlobCourierTests: XCTestCase {
             self.sut?.uploadBlob(input: [
              "parts": [
                [
+                 "name": "test",
+                 "payload": "SOME_TEST_STRING",
+                 "type": "string"
+               ],
+               [
                  "name": "file",
                  "payload": [
                     "absoluteFilePath": data["absoluteFilePath"] ?? "",
                     "mimeType": "image/png"
                  ],
                  "type": "file"
-               ],
-               [
-                 "name": "test",
-                 "payload": "SOME_TEST_STRING",
-                 "type": "string"
                ]
              ],
              "taskId": data["taskId"] ?? "",

--- a/src/ExposedTypes.tsx
+++ b/src/ExposedTypes.tsx
@@ -82,6 +82,12 @@ export declare type BlobMultipart = {
   type: BlobMultipartType;
 };
 
+export declare type BlobMultipartWithName = BlobMultipart & {
+  name: string;
+};
+
+export declare type BlobNamedMultipartArray = BlobMultipartWithName[];
+
 export declare interface BlobMultipartFormDataFile {
   readonly absoluteFilePath: string;
   readonly filename?: string;
@@ -98,13 +104,19 @@ export declare interface BlobUploadRequest
   readonly multipartName?: string;
 }
 
-export declare interface BlobMultipartUploadRequest
+export declare interface BlobMultipartBaseRequest
   extends BlobBaseRequest,
     BlobRequestMethod,
-    BlobRequestReturnResponse {
-  readonly parts: {
-    [key: string]: BlobMultipart;
-  };
+    BlobRequestReturnResponse {}
+
+export declare interface BlobMultipartArrayUploadRequest
+  extends BlobMultipartBaseRequest {
+  readonly parts: BlobNamedMultipartArray;
+}
+
+export declare interface BlobMultipartMapUploadRequest
+  extends BlobMultipartBaseRequest {
+  readonly parts: { [key: string]: BlobMultipart };
 }
 
 export declare interface BlobRequestTask {

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -104,9 +104,7 @@ export const sanitizeMappedMultiparts = (mapped: {
   }
 
   if (receivedInvalidSymbols) {
-    throw new Error(
-      'Use Symbol.forKey when using Symbols as key for multiparts'
-    );
+    throw new Error('Use Symbol.for when using Symbols as key for multiparts');
   }
 
   return regularKeys.length > 0

--- a/src/Utils.tsx
+++ b/src/Utils.tsx
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { BlobNamedMultipartArray, BlobMultipart } from './ExposedTypes';
+
 // Taken from https://github.com/joltup/rn-fetch-blob/blob/master/utils/uuid.js
 const createUuidPart = () => Math.random().toString(36).substring(2, 15);
 
@@ -70,3 +72,11 @@ export const fallbackObjects = (
     };
   }, {});
 };
+
+export const convertMappedMultipartsToArray = (mappedParts: {
+  [key: string]: BlobMultipart;
+}): BlobNamedMultipartArray =>
+  Object.entries(mappedParts).map(([name, part]) => ({
+    ...part,
+    name,
+  }));

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -482,7 +482,38 @@ describe('Given a regular upload request', () => {
     verifyPropertyExistsAndIsDefined(calledWithParameters.parts, multipartName);
   });
 
-  testAsync('JSON multi-part payloads are serialized', async () => {
+  testAsync(
+    'Multipart fields are sent to native code in the order they were provided',
+    async () => {
+      const multipartName1 = 'bbbbb';
+      const multipartName2 = 'aaaaa';
+
+      await BlobCourier.uploadParts({
+        ...DEFAULT_UPLOAD_REQUEST,
+        parts: {
+          [multipartName1]: {
+            payload: 'part1',
+            type: 'string',
+          },
+          [multipartName2]: {
+            payload: 'part2',
+            type: 'string',
+          },
+        },
+      });
+
+      const calledWithParameters = getLastMockCallFirstParameter(
+        BlobCourierNative.uploadBlob
+      );
+
+      expect(Object.keys(calledWithParameters.parts)).toEqual([
+        multipartName1,
+        multipartName2,
+      ]);
+    }
+  );
+
+  testAsync('JSON multipart payloads are serialized', async () => {
     await BlobCourier.uploadParts({
       ...DEFAULT_UPLOAD_REQUEST,
       parts: {
@@ -503,7 +534,7 @@ describe('Given a regular upload request', () => {
   });
 
   testAsync(
-    'The native module is called with all required multi part-values',
+    'The native module is called with all required multipart-values',
     async () => {
       const progressIntervalMilliseconds = Math.random();
       await BlobCourier.uploadParts(DEFAULT_MULTIPART_UPLOAD_REQUEST);
@@ -601,7 +632,7 @@ describe('Given a fluent upload request', () => {
       }
     );
 
-    describe('And a progress updater is provided provided', () => {
+    describe('And a progress updater is provided', () => {
       testAsync(
         'The native module is called with all required multi part-values and the provided settings',
         async () => {
@@ -629,7 +660,7 @@ describe('Given a fluent upload request', () => {
     });
 
     testAsync(
-      'The native module is called with all required multi part-values and the provided settings',
+      'The native module is called with all required multipart-values and the provided settings',
       async () => {
         const progressIntervalMilliseconds = Math.random();
         await BlobCourier.settings({

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -656,7 +656,7 @@ describe('Given a regular upload request', () => {
     );
 
     testAsync(
-      'And they are Symbols not generated with Symbol.forKey, the upload rejects',
+      'And they are Symbols not generated with Symbol.for, the upload rejects',
       async () => {
         const multipartName1 = '3';
         const multipartName2 = '1';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,10 +23,13 @@ import type {
   BlobProgressEvent,
   BlobRequestOnProgress,
   AndroidFetchSettings,
-  BlobMultipartUploadRequest as BlobUploadMultipartRequest,
   IOSFetchSettings,
+  BlobMultipartMapUploadRequest,
+  BlobMultipartArrayUploadRequest,
+  BlobNamedMultipartArray,
+  BlobMultipartWithName,
 } from './ExposedTypes';
-import { uuid } from './Utils';
+import { convertMappedMultipartsToArray, uuid } from './Utils';
 import { dict } from './Extensions';
 
 type BlobFetchInput = BlobFetchRequest &
@@ -40,10 +43,15 @@ type BlobUploadInput = BlobUploadRequest & BlobRequestSettings;
 
 type BlobUploadNativeInput = BlobUploadInput & BlobRequestTask;
 
-type BlobUploadMultipartInput = BlobUploadMultipartRequest &
+type BlobUploadMultipartInput = BlobMultipartMapUploadRequest &
   BlobRequestSettings;
 
-type BlobUploadMultipartNativeInput = BlobUploadMultipartInput &
+type BlobUploadMultipartInputWithTask = BlobMultipartMapUploadRequest &
+  BlobRequestSettings &
+  BlobRequestTask;
+
+type BlobUploadMultipartNativeInput = BlobMultipartArrayUploadRequest &
+  BlobRequestSettings &
   BlobRequestTask;
 
 type BlobCourierType = {
@@ -121,19 +129,13 @@ const sanitizeFetchData = <T extends BlobFetchNativeInput>(
   };
 };
 
-const stringifyPartsValues = (parts: { [key: string]: any }) => {
-  const stringify = (part: { [key: string]: any }) =>
+const stringifyPartsValues = (parts: BlobNamedMultipartArray) => {
+  const stringify = (part: BlobMultipartWithName) =>
     part.type === 'string' && typeof part.payload === 'object'
       ? { ...part, payload: JSON.stringify(part.payload) }
       : part;
 
-  return Object.keys(parts).reduce(
-    (p, c) => ({
-      ...p,
-      [c]: stringify(parts[c]),
-    }),
-    {}
-  );
+  return parts.map(stringify);
 };
 
 const sanitizeMultipartUploadData = <T extends BlobUploadMultipartNativeInput>(
@@ -188,14 +190,17 @@ const fetchBlob = <T extends BlobFetchNativeInput>(input: Readonly<T>) =>
     input.onProgress
   );
 
-const uploadParts = <T extends BlobUploadMultipartNativeInput>(
+const uploadParts = <T extends BlobUploadMultipartInputWithTask>(
   input: Readonly<T>
 ) =>
   wrapEmitter(
     input.taskId,
     () =>
       (BlobCourier as BlobCourierType).uploadBlob(
-        sanitizeMultipartUploadData(input)
+        sanitizeMultipartUploadData({
+          ...input,
+          parts: convertMappedMultipartsToArray(input.parts),
+        })
       ),
     input.onProgress
   );
@@ -237,7 +242,7 @@ const onProgress = (
       onProgress: fn,
       taskId,
     }),
-  uploadParts: (input: BlobUploadMultipartRequest) =>
+  uploadParts: (input: BlobUploadMultipartInput) =>
     uploadParts({
       ...input,
       ...requestSettings,


### PR DESCRIPTION
# Progress
- [x] Verify with automated test that TypeScript hands fields in provided order to native code
- [x] Investigate key ordering in TypeScript/Kotlin/Swift (see comments for findings)
- [x] Provide the required order of the multipart field names to native code
- [x] Fix order in Kotlin
- [x] Verify order with automated test in Kotlin
- [x] Fix order in Swift
- [x] Verify order with automated test in Swift
- [x] Add TypeScript ordering test with numeric key as part name
~- [ ] Move from `Object` to `Map`, if resulting `Object.keys` order is not the same as the provided order~ (this is too intrusive for what is _probably_ mostly an edge case)
- [x] Handle `Symbols` as keys, which guarantees order, even for numeric field names.