### PR TITLE
fix: workaround android-emulator-runner 2.14.0 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           java-version: 1.8
       - run: cd example && yarn
       - run: yarn
-      - uses: reactivecircus/android-emulator-runner@v2
+      - uses: reactivecircus/android-emulator-runner@v2.13.0
         with:
           api-level: 30
           script: ./gradlew connectedAndroidTest


### PR DESCRIPTION
This is a workaround for: https://github.com/ReactiveCircus/android-emulator-runner/issues/113