### PR TITLE
improvement: simplify threaded Android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,13 @@ jobs:
           java-version: 1.8
       - run: yarn
       - uses: reactivecircus/android-emulator-runner@v2.13.0
+        env:
+          ORG_GRADLE_PROJECT_ADB_COMMAND_TIMEOUT_MILLISECONDS: ${{ secrets.ORG_GRADLE_PROJECT_ADB_COMMAND_TIMEOUT_MILLISECONDS }}
+          ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS: ${{ secrets.ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS }}
         with:
           api-level: 30
           script: |
+            echo "ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS ${ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS}"
             adb logcat -c
             adb logcat | grep 'io.deckers.blob_courier' &
             ./gradlew connectedAndroidTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,49 +2,50 @@ name: Build and test
 on: push
 
 jobs:
-  build-typescript:
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
-      - run: yarn
-  run-typescript-tests:
-    needs: build-typescript
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
-      - run: yarn
-      - run: yarn test
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ts-test-results
-          path: output/typescript-test-output.xml
-  run-android-unit-tests:
-    needs: build-typescript
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - run: yarn
-      - uses: eskatos/gradle-command-action@v1
-        with:
-          build-root-directory: android
-          wrapper-directory: android
-          arguments: testDebugUnitTest
-      - uses: actions/upload-artifact@v2
-        with:
-          name: android-unit-test-results
-          path: android/build/test-results/**/*.xml
+  # build-typescript:
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2-beta
+  #       with:
+  #         node-version: '12'
+  #     - run: yarn
+  # run-typescript-tests:
+  #   needs: build-typescript
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-node@v2-beta
+  #       with:
+  #         node-version: '12'
+  #     - run: yarn
+  #     - run: yarn test
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ts-test-results
+  #         path: output/typescript-test-output.xml
+  # run-android-unit-tests:
+  #   needs: build-typescript
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/checkout@v2
+  #     - name: set up JDK 1.8
+  #       uses: actions/setup-java@v1
+  #       with:
+  #         java-version: 1.8
+  #     - run: yarn
+  #     - uses: eskatos/gradle-command-action@v1
+  #       with:
+  #         build-root-directory: android
+  #         wrapper-directory: android
+  #         arguments: testDebugUnitTest
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: android-unit-test-results
+  #         path: android/build/test-results/**/*.xml
   run-android-instrumented-tests:
-    needs: build-typescript
+    continue-on-error: true
+  #  needs: build-typescript
     runs-on: macos-latest
     steps: 
       - uses: actions/checkout@v2
@@ -56,94 +57,103 @@ jobs:
       - uses: reactivecircus/android-emulator-runner@v2.13.0
         with:
           api-level: 30
-          script: ./gradlew connectedAndroidTest
+          script: |
+            adb logcat -c
+            adb logcat &
+            ./gradlew connectedAndroidTest
           target: google_apis
           working-directory: './android' 
       - uses: actions/upload-artifact@v2
         with:
           name: android-instrumented-test-results
           path: android/build/outputs/androidTest-results/connected/flavors/debugAndroidTest/*.xml
-  run-ios-tests:
-    needs: build-typescript
-    runs-on: macos-latest
-    steps: 
-      - uses: actions/checkout@v2
-      - run: xcrun simctl boot "iPhone 11"
-      - uses: actions/setup-node@v2-beta
-        with:
-          node-version: '12'
-      - run: yarn
-      - run: cd ios && pod install
-      - run: xcodebuild test -scheme BlobCourierTests -destination 'platform=iOS Simulator,name=iPhone 11' -workspace 'ios/BlobCourier.xcworkspace' | xcpretty --report junit
+        if: always()
       - uses: actions/upload-artifact@v2
         with:
-          name: ios-test-results
-          path: build/reports/**/*.xml
-  publish-typescript-test-results:
-    needs:
-      - run-typescript-tests
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/download-artifact@v2
-        with:
-          name: ts-test-results
-          path: report-ts
-      - uses: EnricoMi/publish-unit-test-result-action@v1.6
-        with:
-          check_name: "Tests: TypeScript"
-          comment_title: TypeScript Test Report
-          deduplicate_classes_by_file_name: false
-          files: report-ts/**/*.xml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          hide_comments: all but latest
-          report_individual_runs: true
-  publish-android-test-results:
-    needs:
-      - run-android-unit-tests
-      - run-android-instrumented-tests
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/download-artifact@v2
-        with:
-          name: android-unit-test-results
-          path: report-android-unit
-      - uses: actions/download-artifact@v2
-        with:
-          name: android-instrumented-test-results
-          path: report-android-instrument
-      - uses: EnricoMi/publish-unit-test-result-action@v1.6
-        with:
-          check_name: "Tests: Android - Unit"
-          comment_title: Android Unit Test Report
-          deduplicate_classes_by_file_name: false
-          files: report-android-unit/**/*.xml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          hide_comments: all but latest
-          report_individual_runs: true
-      - uses: EnricoMi/publish-unit-test-result-action@v1.6
-        with:
-          check_name: "Tests: Android - Instrumented"
-          comment_title: Android Instrumented Test Report
-          deduplicate_classes_by_file_name: false
-          files: report-android-instrument/**/*.xml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          hide_comments: all but latest
-          report_individual_runs: true
-  publish-ios-test-results:
-    needs:
-      - run-ios-tests
-    runs-on: ubuntu-latest
-    steps: 
-      - uses: actions/download-artifact@v2
-        with:
-          name: ios-test-results
-          path: report-ios
-      - uses: EnricoMi/publish-unit-test-result-action@v1.6
-        with:
-          check_name: "Tests: iOS"
-          comment_title: iOS Test Report
-          deduplicate_classes_by_file_name: false
-          files: report-ios/**/*.xml
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          hide_comments: all but latest
-          report_individual_runs: true
+          name: android-instrumented-logcat
+          path: android_instrumented_logcat.log
+        if: always()
+  # run-ios-tests:
+  #   needs: build-typescript
+  #   runs-on: macos-latest
+  #   steps: 
+  #     - uses: actions/checkout@v2
+  #     - run: xcrun simctl boot "iPhone 11"
+  #     - uses: actions/setup-node@v2-beta
+  #       with:
+  #         node-version: '12'
+  #     - run: yarn
+  #     - run: cd ios && pod install
+  #     - run: xcodebuild test -scheme BlobCourierTests -destination 'platform=iOS Simulator,name=iPhone 11' -workspace 'ios/BlobCourier.xcworkspace' | xcpretty --report junit
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ios-test-results
+  #         path: build/reports/**/*.xml
+  # publish-typescript-test-results:
+  #   needs:
+  #     - run-typescript-tests
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: ts-test-results
+  #         path: report-ts
+  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
+  #       with:
+  #         check_name: "Tests: TypeScript"
+  #         comment_title: TypeScript Test Report
+  #         deduplicate_classes_by_file_name: false
+  #         files: report-ts/**/*.xml
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         hide_comments: all but latest
+  #         report_individual_runs: true
+  # publish-android-test-results:
+  #   needs:
+  #     - run-android-unit-tests
+  #     - run-android-instrumented-tests
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: android-unit-test-results
+  #         path: report-android-unit
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: android-instrumented-test-results
+  #         path: report-android-instrument
+  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
+  #       with:
+  #         check_name: "Tests: Android - Unit"
+  #         comment_title: Android Unit Test Report
+  #         deduplicate_classes_by_file_name: false
+  #         files: report-android-unit/**/*.xml
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         hide_comments: all but latest
+  #         report_individual_runs: true
+  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
+  #       with:
+  #         check_name: "Tests: Android - Instrumented"
+  #         comment_title: Android Instrumented Test Report
+  #         deduplicate_classes_by_file_name: false
+  #         files: report-android-instrument/**/*.xml
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         hide_comments: all but latest
+  #         report_individual_runs: true
+  # publish-ios-test-results:
+  #   needs:
+  #     - run-ios-tests
+  #   runs-on: ubuntu-latest
+  #   steps: 
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: ios-test-results
+  #         path: report-ios
+  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
+  #       with:
+  #         check_name: "Tests: iOS"
+  #         comment_title: iOS Test Report
+  #         deduplicate_classes_by_file_name: false
+  #         files: report-ios/**/*.xml
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         hide_comments: all but latest
+  #         report_individual_runs: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,50 +2,50 @@ name: Build and test
 on: push
 
 jobs:
-  # build-typescript:
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2-beta
-  #       with:
-  #         node-version: '12'
-  #     - run: yarn
-  # run-typescript-tests:
-  #   needs: build-typescript
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v2-beta
-  #       with:
-  #         node-version: '12'
-  #     - run: yarn
-  #     - run: yarn test
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ts-test-results
-  #         path: output/typescript-test-output.xml
-  # run-android-unit-tests:
-  #   needs: build-typescript
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/checkout@v2
-  #     - name: set up JDK 1.8
-  #       uses: actions/setup-java@v1
-  #       with:
-  #         java-version: 1.8
-  #     - run: yarn
-  #     - uses: eskatos/gradle-command-action@v1
-  #       with:
-  #         build-root-directory: android
-  #         wrapper-directory: android
-  #         arguments: testDebugUnitTest
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: android-unit-test-results
-  #         path: android/build/test-results/**/*.xml
+  build-typescript:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - run: yarn
+  run-typescript-tests:
+    needs: build-typescript
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - run: yarn
+      - run: yarn test
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ts-test-results
+          path: output/typescript-test-output.xml
+  run-android-unit-tests:
+    needs: build-typescript
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - run: yarn
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          build-root-directory: android
+          wrapper-directory: android
+          arguments: testDebugUnitTest
+      - uses: actions/upload-artifact@v2
+        with:
+          name: android-unit-test-results
+          path: android/build/test-results/**/*.xml
   run-android-instrumented-tests:
     continue-on-error: true
-  #  needs: build-typescript
+    needs: build-typescript
     runs-on: macos-latest
     steps: 
       - uses: actions/checkout@v2
@@ -77,87 +77,87 @@ jobs:
           name: android-instrumented-logcat
           path: android_instrumented_logcat.log
         if: always()
-  # run-ios-tests:
-  #   needs: build-typescript
-  #   runs-on: macos-latest
-  #   steps: 
-  #     - uses: actions/checkout@v2
-  #     - run: xcrun simctl boot "iPhone 11"
-  #     - uses: actions/setup-node@v2-beta
-  #       with:
-  #         node-version: '12'
-  #     - run: yarn
-  #     - run: cd ios && pod install
-  #     - run: xcodebuild test -scheme BlobCourierTests -destination 'platform=iOS Simulator,name=iPhone 11' -workspace 'ios/BlobCourier.xcworkspace' | xcpretty --report junit
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: ios-test-results
-  #         path: build/reports/**/*.xml
-  # publish-typescript-test-results:
-  #   needs:
-  #     - run-typescript-tests
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: ts-test-results
-  #         path: report-ts
-  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
-  #       with:
-  #         check_name: "Tests: TypeScript"
-  #         comment_title: TypeScript Test Report
-  #         deduplicate_classes_by_file_name: false
-  #         files: report-ts/**/*.xml
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         hide_comments: all but latest
-  #         report_individual_runs: true
-  # publish-android-test-results:
-  #   needs:
-  #     - run-android-unit-tests
-  #     - run-android-instrumented-tests
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: android-unit-test-results
-  #         path: report-android-unit
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: android-instrumented-test-results
-  #         path: report-android-instrument
-  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
-  #       with:
-  #         check_name: "Tests: Android - Unit"
-  #         comment_title: Android Unit Test Report
-  #         deduplicate_classes_by_file_name: false
-  #         files: report-android-unit/**/*.xml
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         hide_comments: all but latest
-  #         report_individual_runs: true
-  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
-  #       with:
-  #         check_name: "Tests: Android - Instrumented"
-  #         comment_title: Android Instrumented Test Report
-  #         deduplicate_classes_by_file_name: false
-  #         files: report-android-instrument/**/*.xml
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         hide_comments: all but latest
-  #         report_individual_runs: true
-  # publish-ios-test-results:
-  #   needs:
-  #     - run-ios-tests
-  #   runs-on: ubuntu-latest
-  #   steps: 
-  #     - uses: actions/download-artifact@v2
-  #       with:
-  #         name: ios-test-results
-  #         path: report-ios
-  #     - uses: EnricoMi/publish-unit-test-result-action@v1.6
-  #       with:
-  #         check_name: "Tests: iOS"
-  #         comment_title: iOS Test Report
-  #         deduplicate_classes_by_file_name: false
-  #         files: report-ios/**/*.xml
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #         hide_comments: all but latest
-  #         report_individual_runs: true
+  run-ios-tests:
+    needs: build-typescript
+    runs-on: macos-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - run: xcrun simctl boot "iPhone 11"
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+      - run: yarn
+      - run: cd ios && pod install
+      - run: xcodebuild test -scheme BlobCourierTests -destination 'platform=iOS Simulator,name=iPhone 11' -workspace 'ios/BlobCourier.xcworkspace' | xcpretty --report junit
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ios-test-results
+          path: build/reports/**/*.xml
+  publish-typescript-test-results:
+    needs:
+      - run-typescript-tests
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/download-artifact@v2
+        with:
+          name: ts-test-results
+          path: report-ts
+      - uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: "Tests: TypeScript"
+          comment_title: TypeScript Test Report
+          deduplicate_classes_by_file_name: false
+          files: report-ts/**/*.xml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          hide_comments: all but latest
+          report_individual_runs: true
+  publish-android-test-results:
+    needs:
+      - run-android-unit-tests
+      - run-android-instrumented-tests
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/download-artifact@v2
+        with:
+          name: android-unit-test-results
+          path: report-android-unit
+      - uses: actions/download-artifact@v2
+        with:
+          name: android-instrumented-test-results
+          path: report-android-instrument
+      - uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: "Tests: Android - Unit"
+          comment_title: Android Unit Test Report
+          deduplicate_classes_by_file_name: false
+          files: report-android-unit/**/*.xml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          hide_comments: all but latest
+          report_individual_runs: true
+      - uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: "Tests: Android - Instrumented"
+          comment_title: Android Instrumented Test Report
+          deduplicate_classes_by_file_name: false
+          files: report-android-instrument/**/*.xml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          hide_comments: all but latest
+          report_individual_runs: true
+  publish-ios-test-results:
+    needs:
+      - run-ios-tests
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/download-artifact@v2
+        with:
+          name: ios-test-results
+          path: report-ios
+      - uses: EnricoMi/publish-unit-test-result-action@v1.6
+        with:
+          check_name: "Tests: iOS"
+          comment_title: iOS Test Report
+          deduplicate_classes_by_file_name: false
+          files: report-ios/**/*.xml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          hide_comments: all but latest
+          report_individual_runs: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           api-level: 30
           script: |
             adb logcat -c
-            adb logcat &
+            adb logcat | grep 'io.deckers.blob_courier' &
             ./gradlew connectedAndroidTest
           target: google_apis
           working-directory: './android' 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           build-root-directory: android
           wrapper-directory: android
-          arguments: testDebugUnitTest
+          arguments: testDebugUnitTest --tests=BlobCourierModuleTests
       - uses: actions/upload-artifact@v2
         with:
           name: android-unit-test-results

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,6 +152,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.android.support:multidex:1.0.3'
   implementation "com.squareup.okhttp3:okhttp:3.14.9"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
   testImplementation 'androidx.test:core:1.3.0'
   testImplementation 'junit:junit:4.13.1'
   testImplementation "io.mockk:mockk:1.10.2"
@@ -159,6 +160,7 @@ dependencies {
   testImplementation "io.mockk:mockk-agent-jvm:1.10.2"
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
   testImplementation 'org.robolectric:robolectric:4.4'
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
   androidTestImplementation "io.mockk:mockk-android:1.10.2"
   androidTestImplementation 'androidx.test.ext:junit:1.1.2'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,8 @@ android {
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     multiDexEnabled true
+    buildConfigField "Long", "ADB_COMMAND_TIMEOUT_MILLISECONDS", ADB_COMMAND_TIMEOUT_MILLISECONDS
+    buildConfigField "Long", "PROMISE_TIMEOUT_MILLISECONDS", PROMISE_TIMEOUT_MILLISECONDS
   }
 
   packagingOptions {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,4 +3,7 @@ BlobCourier_compileSdkVersion = 30
 BlobCourier_buildToolsVersion = 30.0.0
 BlobCourier_targetSdkVersion = 29
 
+ADB_COMMAND_TIMEOUT_MILLISECONDS = 10000L
+PROMISE_TIMEOUT_MILLISECONDS = 60000L
+
 android.useAndroidX = true

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.withTimeout
 import org.junit.Before
 import org.junit.Test
 
-private const val TAG = "InstrumentedTests"
+private val TAG = BlobCourierInstrumentedModuleTests::class.java.name
 
 private val logger = Logger(TAG)
 private fun li(m: String) = logger.i(m)

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -16,7 +16,7 @@ import io.deckers.blob_courier.Fixtures.runFetchBlobSuspend
 import io.deckers.blob_courier.TestUtils.assertRequestFalse
 import io.deckers.blob_courier.TestUtils.assertRequestTrue
 import io.deckers.blob_courier.TestUtils.circumventHiddenApiExemptionsForMockk
-import io.deckers.blob_courier.TestUtils.runRequestToBoolean
+import io.deckers.blob_courier.TestUtils.runInstrumentedRequestToBoolean
 import io.deckers.blob_courier.common.DOWNLOAD_TYPE_MANAGED
 import io.deckers.blob_courier.common.MANAGED_DOWNLOAD_SUCCESS
 import io.deckers.blob_courier.common.left
@@ -27,7 +27,6 @@ import io.mockk.mockkStatic
 import java.util.UUID
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
@@ -41,13 +40,6 @@ private fun enableNetworking(enable: Boolean) {
 }
 
 class BlobCourierInstrumentedModuleTests {
-  @After
-  fun restoreExpectedState() = runBlocking {
-    enableNetworking(true)
-
-    delay(ADB_COMMAND_DELAY_MILLISECONDS)
-  }
-
   @Before
   fun mockSomeNativeOnlyMethods() {
     circumventHiddenApiExemptionsForMockk()
@@ -71,14 +63,15 @@ class BlobCourierInstrumentedModuleTests {
     val ctx = InstrumentationRegistry.getInstrumentation().targetContext
     val reactContext = ReactApplicationContext(ctx)
 
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(true)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       runFetchBlobSuspend(
         reactContext,
         allRequiredParametersMap
       )
-    })
+    }
 
     assertRequestTrue(message, succeeded)
   }
@@ -97,9 +90,8 @@ class BlobCourierInstrumentedModuleTests {
     val ctx = InstrumentationRegistry.getInstrumentation().targetContext
     val reactContext = ReactApplicationContext(ctx)
 
-    enableNetworking(true)
-
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(true)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       runFetchBlobSuspend(reactContext, allRequiredParametersMap)
@@ -109,7 +101,7 @@ class BlobCourierInstrumentedModuleTests {
 
           if (check) right(result) else left("Received incorrect type `$receivedType`")
         }
-    })
+    }
 
     assertRequestTrue(message, succeeded)
   }
@@ -127,7 +119,8 @@ class BlobCourierInstrumentedModuleTests {
     val ctx = InstrumentationRegistry.getInstrumentation().targetContext
     val reactContext = ReactApplicationContext(ctx)
 
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(true)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       runFetchBlobSuspend(reactContext, allRequiredParametersMap)
@@ -137,7 +130,7 @@ class BlobCourierInstrumentedModuleTests {
 
           if (check) right(result) else left("Received incorrect result `$receivedResult`")
         }
-    })
+    }
 
     assertRequestTrue(message, succeeded)
   }
@@ -154,11 +147,12 @@ class BlobCourierInstrumentedModuleTests {
         someFileThatIsAlwaysAvailable
       )
 
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(true)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       Fixtures.runUploadBlobSuspend(ctx, uploadParametersMap.toReactMap())
-    })
+    }
 
     assertRequestTrue(message, succeeded)
   }
@@ -172,11 +166,12 @@ class BlobCourierInstrumentedModuleTests {
 
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(true)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       Fixtures.runUploadBlobSuspend(ctx, allRequiredParametersMap.toReactMap())
-    })
+    }
 
     assertRequestFalse(message, succeeded)
   }
@@ -188,13 +183,12 @@ class BlobCourierInstrumentedModuleTests {
 
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
-    enableNetworking(false)
-
-    val (succeeded, message) = runRequestToBoolean({
+    val (succeeded, message) = runInstrumentedRequestToBoolean {
+      enableNetworking(false)
       delay(ADB_COMMAND_DELAY_MILLISECONDS)
 
       runFetchBlobSuspend(ctx, allRequiredParametersMap.toReactMap())
-    })
+    }
 
     assertRequestFalse(message, succeeded)
   }

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -58,7 +58,7 @@ class BlobCourierInstrumentedModuleTests {
     every { Arguments.createArray() } answers { JavaOnlyArray() }
   }
 
-//  @Ignore("This breaks on GitHub Actions due to timeout")
+  //  @Ignore("This breaks on GitHub Actions due to timeout")
   @Test
   fun managed_download_succeeds() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -83,7 +83,7 @@ class BlobCourierInstrumentedModuleTests {
     assertRequestTrue(message, succeeded)
   }
 
-//  @Ignore("This breaks on GitHub Actions due to timeout")
+  //  @Ignore("This breaks on GitHub Actions due to timeout")
   @Test
   fun managed_download_returns_correct_type() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -96,6 +96,8 @@ class BlobCourierInstrumentedModuleTests {
 
     val ctx = InstrumentationRegistry.getInstrumentation().targetContext
     val reactContext = ReactApplicationContext(ctx)
+
+    enableNetworking(true)
 
     val (succeeded, message) = runRequestToBoolean({
       delay(ADB_COMMAND_DELAY_MILLISECONDS)

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Test
 
-private const val ADB_COMMAND_DELAY_MILLISECONDS = 5_000L
+private const val ADB_COMMAND_DELAY_MILLISECONDS = 8_000L
 
 private fun enableNetworking(enable: Boolean) {
   val word = if (enable) "enable" else "disable"

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -22,7 +22,6 @@ import io.deckers.blob_courier.common.Logger
 import io.deckers.blob_courier.common.Success
 import io.deckers.blob_courier.common.`do`
 import io.deckers.blob_courier.common.fold
-import io.deckers.blob_courier.common.tag
 import io.deckers.blob_courier.fetch.BlobDownloader
 import io.deckers.blob_courier.fetch.DownloaderParameterFactory
 import io.deckers.blob_courier.react.CongestionAvoidingProgressNotifierFactory
@@ -42,7 +41,7 @@ private fun createProgressFactory(reactContext: ReactApplicationContext) =
     DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS
   )
 
-private val TAG = tag(BlobCourierModule::class.java.name)
+private val TAG = BlobCourierModule::class.java.name
 private val logger = Logger(TAG)
 private fun le(m: String, e: Throwable? = null) = logger.e(m, e)
 private fun li(m: String) = logger.i(m)

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -29,7 +29,8 @@ import io.deckers.blob_courier.react.toReactMap
 import io.deckers.blob_courier.upload.BlobUploader
 import io.deckers.blob_courier.upload.UploaderParameterFactory
 import java.net.UnknownHostException
-import kotlin.concurrent.thread
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private fun createHttpClient() = OkHttpClientProvider.getOkHttpClient()
 private fun createProgressFactory(reactContext: ReactApplicationContext) =
@@ -44,9 +45,9 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
   override fun getName(): String = LIBRARY_NAME
 
   @ReactMethod
-  fun fetchBlob(input: ReadableMap, promise: Promise) {
-    thread {
-      try {
+  suspend fun fetchBlob(input: ReadableMap, promise: Promise) {
+    try {
+      withContext(Dispatchers.IO) {
         val errorOrDownloadResult =
           DownloaderParameterFactory()
             .fromInput(input)
@@ -65,20 +66,20 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
             { f -> promise.reject(f.code, f.message) },
             promise::resolve
           )
-      } catch (e: UnknownHostException) {
-        promise.reject(ERROR_UNKNOWN_HOST, e)
-      } catch (e: Exception) {
-        promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedException(e).message)
-      } catch (e: Error) {
-        promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedError(e).message)
       }
+    } catch (e: UnknownHostException) {
+      promise.reject(ERROR_UNKNOWN_HOST, e)
+    } catch (e: Exception) {
+      promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedException(e).message)
+    } catch (e: Error) {
+      promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedError(e).message)
     }
   }
 
   @ReactMethod
-  fun uploadBlob(input: ReadableMap, promise: Promise) {
-    thread {
-      try {
+  suspend fun uploadBlob(input: ReadableMap, promise: Promise) {
+    try {
+      withContext(Dispatchers.IO) {
         UploaderParameterFactory()
           .fromInput(input)
           .fold(::Failure, ::Success)
@@ -94,13 +95,13 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
             { f -> promise.reject(f.code, f.message) },
             promise::resolve
           )
-      } catch (e: UnknownHostException) {
-        promise.reject(ERROR_UNKNOWN_HOST, e)
-      } catch (e: Exception) {
-        promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedException(e).message)
-      } catch (e: Error) {
-        promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedError(e).message)
       }
+    } catch (e: UnknownHostException) {
+      promise.reject(ERROR_UNKNOWN_HOST, e)
+    } catch (e: Exception) {
+      promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedException(e).message)
+    } catch (e: Error) {
+      promise.reject(ERROR_UNEXPECTED_EXCEPTION, processUnexpectedError(e).message)
     }
   }
 }

--- a/android/src/main/java/io/deckers/blob_courier/common/Logger.kt
+++ b/android/src/main/java/io/deckers/blob_courier/common/Logger.kt
@@ -8,6 +8,3 @@ class Logger(private val tag: String) {
   fun v(message: String, throwable: Throwable? = null) = Log.v(tag, message, throwable)
   fun w(message: String, throwable: Throwable? = null) = Log.w(tag, message, throwable)
 }
-
-// fun tag(tag:String) = "io.deckers.blob_courier.$tag"
-fun tag(tag: String) = tag

--- a/android/src/main/java/io/deckers/blob_courier/common/Logger.kt
+++ b/android/src/main/java/io/deckers/blob_courier/common/Logger.kt
@@ -1,0 +1,13 @@
+package io.deckers.blob_courier.common
+
+import android.util.Log
+
+class Logger(private val tag: String) {
+  fun e(message: String, throwable: Throwable? = null) = Log.e(tag, message, throwable)
+  fun i(message: String) = Log.i(tag, message)
+  fun v(message: String, throwable: Throwable? = null) = Log.v(tag, message, throwable)
+  fun w(message: String, throwable: Throwable? = null) = Log.w(tag, message, throwable)
+}
+
+// fun tag(tag:String) = "io.deckers.blob_courier.$tag"
+fun tag(tag: String) = tag

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
@@ -62,8 +62,8 @@ class ManagedDownloadReceiver(
 
   private fun processCompletedDownloadStatus(context: Context, cursor: Cursor) {
     val columnIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
-
-    val isStatusSuccessful = cursor.getInt(columnIndex) == DownloadManager.STATUS_SUCCESSFUL
+    val status = cursor.getInt(columnIndex)
+    val isStatusSuccessful = status == DownloadManager.STATUS_SUCCESSFUL
 
     if (isStatusSuccessful) {
       val localFileUri =
@@ -78,7 +78,7 @@ class ManagedDownloadReceiver(
       Failure(
         BlobCourierError(
           MANAGED_DOWNLOAD_FAILURE,
-          "Something went wrong retrieving download status"
+          "Something went wrong retrieving download status (status=$status)"
         )
       )
     )

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
@@ -23,14 +23,13 @@ import io.deckers.blob_courier.common.Result
 import io.deckers.blob_courier.common.Success
 import io.deckers.blob_courier.common.createDownloadManager
 import io.deckers.blob_courier.common.createErrorFromThrowabe
-import io.deckers.blob_courier.common.tag
 import io.deckers.blob_courier.progress.ManagedProgressUpdater
 import java.io.Closeable
 import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 
-private val TAG = tag(ManagedDownloadReceiver::class.java.name)
+private val TAG = ManagedDownloadReceiver::class.java.name
 private val logger = Logger(TAG)
 private fun lv(m: String, e: Throwable? = null) = logger.v(m, e)
 private fun lw(m: String, e: Throwable? = null) = logger.w(m, e)

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
@@ -18,7 +18,6 @@ import io.deckers.blob_courier.common.MANAGED_DOWNLOAD_FAILURE
 import io.deckers.blob_courier.common.Result
 import io.deckers.blob_courier.common.createErrorFromThrowabe
 import io.deckers.blob_courier.common.fold
-import io.deckers.blob_courier.common.tag
 import io.deckers.blob_courier.progress.ManagedProgressUpdater
 import io.deckers.blob_courier.progress.ProgressNotifier
 import java.io.File
@@ -27,7 +26,7 @@ private const val DOWNLOAD_MANAGER_PARAMETER_DESCRIPTION = "description"
 private const val DOWNLOAD_MANAGER_PARAMETER_ENABLE_NOTIFICATIONS = "enableNotifications"
 private const val DOWNLOAD_MANAGER_PARAMETER_TITLE = "title"
 
-private val TAG = tag(ManagedDownloader::class.java.name)
+private val TAG = ManagedDownloader::class.java.name
 private val logger = Logger(TAG)
 private fun li(m: String) = logger.i(m)
 private fun lv(m: String, e: Throwable? = null) = logger.v(m, e)

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
@@ -13,9 +13,12 @@ import com.facebook.react.bridge.ReactApplicationContext
 import io.deckers.blob_courier.common.BlobCourierError
 import io.deckers.blob_courier.common.ERROR_UNEXPECTED_ERROR
 import io.deckers.blob_courier.common.Failure
+import io.deckers.blob_courier.common.Logger
 import io.deckers.blob_courier.common.MANAGED_DOWNLOAD_FAILURE
 import io.deckers.blob_courier.common.Result
 import io.deckers.blob_courier.common.createErrorFromThrowabe
+import io.deckers.blob_courier.common.fold
+import io.deckers.blob_courier.common.tag
 import io.deckers.blob_courier.progress.ManagedProgressUpdater
 import io.deckers.blob_courier.progress.ProgressNotifier
 import java.io.File
@@ -23,6 +26,11 @@ import java.io.File
 private const val DOWNLOAD_MANAGER_PARAMETER_DESCRIPTION = "description"
 private const val DOWNLOAD_MANAGER_PARAMETER_ENABLE_NOTIFICATIONS = "enableNotifications"
 private const val DOWNLOAD_MANAGER_PARAMETER_TITLE = "title"
+
+private val TAG = tag(ManagedDownloader::class.java.name)
+private val logger = Logger(TAG)
+private fun li(m: String) = logger.i(m)
+private fun lv(m: String, e: Throwable? = null) = logger.v(m, e)
 
 class ManagedDownloader(
   private val reactContext: ReactApplicationContext,
@@ -36,11 +44,13 @@ class ManagedDownloader(
     toAbsoluteFilePath: File,
   ): Result<Map<String, Any>> {
     try {
+      li("Starting managed fetch")
       val request =
         DownloadManager.Request(downloaderParameters.uri)
           .setAllowedOverRoaming(true)
           .setMimeType(downloaderParameters.mimeType)
           .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+      lv("Created request")
 
       val downloadManagerSettings = downloaderParameters.downloadManagerSettings
       if (downloadManagerSettings.containsKey(DOWNLOAD_MANAGER_PARAMETER_DESCRIPTION)) {
@@ -48,18 +58,21 @@ class ManagedDownloader(
           downloadManagerSettings[DOWNLOAD_MANAGER_PARAMETER_DESCRIPTION] as String
         )
       }
+      lv("Set download description")
 
       if (downloadManagerSettings.containsKey(DOWNLOAD_MANAGER_PARAMETER_TITLE)) {
         request.setTitle(
           downloadManagerSettings[DOWNLOAD_MANAGER_PARAMETER_TITLE] as String
         )
       }
+      lv("Set download title")
 
       val enableNotifications =
         downloadManagerSettings.containsKey(DOWNLOAD_MANAGER_PARAMETER_ENABLE_NOTIFICATIONS) &&
           downloadManagerSettings[DOWNLOAD_MANAGER_PARAMETER_ENABLE_NOTIFICATIONS] == true
 
       request.setNotificationVisibility(if (enableNotifications) 1 else 0)
+      lv("Toggled notification visibility (visibility=$enableNotifications)")
 
       val downloadId = request
         .let { requestBuilder
@@ -74,6 +87,7 @@ class ManagedDownloader(
             requestBuilder
           )
         }
+      lv("Queued request")
 
       val progressUpdater =
         ManagedProgressUpdater(
@@ -84,6 +98,7 @@ class ManagedDownloader(
         )
 
       progressUpdater.start()
+      lv("Started progress updater")
 
       val waitForDownloadCompletion = Object()
 
@@ -97,9 +112,11 @@ class ManagedDownloader(
             progressUpdater
           ) { errorOrResult ->
             result = errorOrResult
+            lv("Finished managed download")
 
             synchronized(waitForDownloadCompletion) {
               waitForDownloadCompletion.notify()
+              lv("Notify lock")
             }
           }
 
@@ -108,7 +125,15 @@ class ManagedDownloader(
           IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
         )
 
+        lv("Registered ${DownloadManager.ACTION_DOWNLOAD_COMPLETE} receiver")
+
+        lv("Waiting for completion")
+
         waitForDownloadCompletion.wait()
+
+        li("Finished managed fetch and returning result")
+
+        lv("Result: ${result?.fold({ it }, { it.toString() }) ?: "NO_RESULT_SET"}")
 
         return result
           ?: Failure(BlobCourierError(MANAGED_DOWNLOAD_FAILURE, "Result was never set"))

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -46,16 +46,6 @@ object Fixtures {
     "https://file.io"
   )
 
-  fun runFetchBlob(
-    context: ReactApplicationContext,
-    input: ReadableMap,
-    promise: Promise,
-  ) {
-    val m = BlobCourierModule(context)
-
-    m.fetchBlob(input, promise)
-  }
-
   suspend fun runFetchBlobSuspend(
     context: ReactApplicationContext,
     input: ReadableMap,
@@ -78,16 +68,6 @@ object Fixtures {
     }
 
     return result ?: left("Did not receive a response in time")
-  }
-
-  fun runUploadBlob(
-    context: ReactApplicationContext,
-    input: ReadableMap,
-    promise: Promise,
-  ) {
-    val m = BlobCourierModule(context)
-
-    m.uploadBlob(input, promise)
   }
 
   suspend fun runUploadBlobSuspend(
@@ -151,35 +131,5 @@ object Fixtures {
       left(message)
 
     override fun reject(message: String?) = left(message ?: "")
-  }
-
-  class BooleanPromise(val c: (Boolean) -> Unit) : Promise {
-    override fun reject(code: String?, message: String?) = c(false)
-
-    override fun reject(code: String?, throwable: Throwable?) = c(false)
-
-    override fun reject(code: String?, message: String?, throwable: Throwable?) = c(false)
-
-    override fun reject(throwable: Throwable?) = c(false)
-
-    override fun reject(throwable: Throwable?, userInfo: WritableMap?) = c(false)
-
-    override fun reject(code: String?, userInfo: WritableMap) = c(false)
-
-    override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap?) = c(false)
-
-    override fun reject(code: String?, message: String?, userInfo: WritableMap) = c(false)
-
-    override fun reject(
-      code: String?,
-      message: String?,
-      throwable: Throwable?,
-      userInfo: WritableMap?
-    ) =
-      c(false)
-
-    override fun reject(message: String?) = c(false)
-
-    override fun resolve(value: Any?) = c(true)
   }
 }

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 
 const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 10_000L
+const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 15_000L
 
 object Fixtures {
 

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -18,9 +18,6 @@ import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 
-const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 10_000L
-const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 60_000L
-
 object Fixtures {
 
   fun createValidTestFetchParameterMap(): Map<String, String> = mapOf(

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 
 const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 10_000L
-const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 15_000L
+const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 20_000L
 
 object Fixtures {
 

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 
 const val DEFAULT_PROMISE_TIMEOUT_MILLISECONDS = 10_000L
-const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 20_000L
+const val DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS = 60_000L
 
 object Fixtures {
 

--- a/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
@@ -63,6 +63,12 @@ object TestUtils {
   ) =
     runRequest(block, timeoutMilliseconds).fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
+  suspend fun runInstrumentedRequestToBoolean(
+    block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
+  ) =
+    runRequest(block, DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS)
+      .fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
+
   fun assertRequestFalse(message: String, b: Boolean) =
     Assert.assertFalse("Resolves, but expected reject: $message", b)
 

--- a/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
@@ -7,7 +7,13 @@
 package io.deckers.blob_courier
 
 import android.os.Build
+import com.facebook.react.bridge.ReadableMap
+import io.deckers.blob_courier.common.Either
+import io.deckers.blob_courier.common.fold
 import java.lang.reflect.Method
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert
 
 object TestUtils {
   private const val vmRuntimeClassName = "dalvik.system.VMRuntime"
@@ -44,4 +50,22 @@ object TestUtils {
       throw Exception("Could not set up hiddenApiExemptions")
     }
   }
+
+  suspend fun runRequest(
+    block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
+    timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
+  ) =
+    withTimeout(timeoutMilliseconds, block)
+
+  suspend fun runRequestToBoolean(
+    block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
+    timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
+  ) =
+    runRequest(block, timeoutMilliseconds).fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
+
+  fun assertRequestFalse(message: String, b: Boolean) =
+    Assert.assertFalse("Resolves, but expected reject: $message", b)
+
+  fun assertRequestTrue(message: String, b: Boolean) =
+    Assert.assertTrue("Rejects, but expected resolve: $message", b)
 }

--- a/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
@@ -8,6 +8,7 @@ package io.deckers.blob_courier
 
 import android.os.Build
 import com.facebook.react.bridge.ReadableMap
+import io.deckers.blob_courier.BuildConfig.PROMISE_TIMEOUT_MILLISECONDS
 import io.deckers.blob_courier.common.Either
 import io.deckers.blob_courier.common.fold
 import java.lang.reflect.Method
@@ -53,20 +54,20 @@ object TestUtils {
 
   suspend fun runRequest(
     block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
-    timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
+    timeoutMilliseconds: Long = PROMISE_TIMEOUT_MILLISECONDS
   ) =
     withTimeout(timeoutMilliseconds, block)
 
   suspend fun runRequestToBoolean(
     block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
-    timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
+    timeoutMilliseconds: Long = PROMISE_TIMEOUT_MILLISECONDS
   ) =
     runRequest(block, timeoutMilliseconds).fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
   suspend fun runInstrumentedRequestToBoolean(
     block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
   ) =
-    runRequest(block, DEFAULT_PROMISE_INSTRUMENTED_TIMEOUT_MILLISECONDS)
+    runRequest(block, PROMISE_TIMEOUT_MILLISECONDS)
       .fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
   fun assertRequestFalse(message: String, b: Boolean) =

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -94,10 +94,8 @@ private fun retrieveMissingKeys(
       }
     )
 
-private fun createAllSingleMissingKeyCombinations(m: Map<*, *>): List<Map<Any?, Any?>> {
-  if (m.keys.isEmpty()) return listOf()
-
-  return m.keys.flatMap { k0 ->
+private fun createAllSingleMissingKeyCombinations(m: Map<*, *>): List<Map<Any?, Any?>> =
+  m.keys.flatMap { k0 ->
     val dictWithoutKey0 = m.filterKeys { k -> k != k0 }
 
     val d0 =
@@ -110,7 +108,6 @@ private fun createAllSingleMissingKeyCombinations(m: Map<*, *>): List<Map<Any?, 
 
     listOf(dictWithoutKey0).plus(d0)
   }
-}
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -371,9 +371,9 @@ class BlobCourierModuleTests {
         SOME_FILE_THAT_IS_ALWAYS_AVAILABLE
       ).toReactMap()
 
-    val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
+    val (succeeded, message) = runRequestToBoolean({
       runUploadBlobSuspend(ctx, uploadParametersMap)
-    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
+    })
 
     assertRequestTrue(message, succeeded)
   }

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -17,6 +17,10 @@ import io.deckers.blob_courier.Fixtures.createValidTestFetchParameterMap
 import io.deckers.blob_courier.Fixtures.createValidUploadTestParameterMap
 import io.deckers.blob_courier.Fixtures.runFetchBlob
 import io.deckers.blob_courier.Fixtures.runUploadBlob
+import io.deckers.blob_courier.category.EndToEnd
+import io.deckers.blob_courier.category.Isolated
+import io.deckers.blob_courier.category.Regression
+import io.deckers.blob_courier.category.Slow
 import io.deckers.blob_courier.common.Either
 import io.deckers.blob_courier.common.ValidationError
 import io.deckers.blob_courier.common.isNotNull
@@ -40,6 +44,7 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
@@ -116,6 +121,7 @@ class BlobCourierModuleTests {
     every { Arguments.createArray() } answers { JavaOnlyArray() }
   }
 
+  @Category(Isolated::class)
   @Test
   fun missing_required_fetch_parameters_rejects_fetch_promise() {
     val allValuesMapping = createValidTestFetchParameterMap()
@@ -127,6 +133,7 @@ class BlobCourierModuleTests {
     }
   }
 
+  @Category(EndToEnd::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun all_required_fetch_parameters_provided_resolves_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -172,6 +179,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun unreachable_fetch_server_rejects_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
@@ -219,6 +227,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class, Slow::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun non_ok_http_fetch_response_resolves_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
@@ -268,6 +277,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun all_required_parameters_provided_resolves_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -331,6 +341,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun using_a_string_payload_resolves_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -406,6 +417,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun non_ok_http_response_resolves_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -472,6 +484,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class, Slow::class)
   @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
   fun unreachable_server_rejects_upload_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
@@ -537,6 +550,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(Isolated::class)
   @Test
   fun total_number_of_bytes_estimate_is_returned_by_input_stream_request_body() {
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
@@ -558,6 +572,7 @@ class BlobCourierModuleTests {
     )
   }
 
+  @Category(Isolated::class)
   @Test
   fun missing_required_upload_parameters_rejects_fetch_promise() {
     val allValuesMapping =
@@ -570,6 +585,7 @@ class BlobCourierModuleTests {
     }
   }
 
+  @Category(EndToEnd::class, Regression::class)
   @Test // This is the faster, and less thorough version of the Instrumented test with the same name
   fun uploading_a_file_from_outside_app_data_directory_resolves_promise() {
 
@@ -623,11 +639,13 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(EndToEnd::class, Regression::class)
   @Test
   fun correct_target_parameters_resolve_promise() {
     listOf("cache", "data").forEach { assert_correct_target_parameter_resolves_promise(it) }
   }
 
+  @Category(EndToEnd::class, Regression::class)
   @Test
   fun incorrect_target_parameter_rejects_promise() {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
@@ -682,6 +700,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(Isolated::class, Regression::class)
   @Test
   fun multipart_parameters_must_be_sent_to_the_server_in_the_order_they_were_provided() {
     val uploadParameterReadableMap =
@@ -717,6 +736,7 @@ class BlobCourierModuleTests {
     }
   }
 
+  @Category(EndToEnd::class)
   @Test // This is the faster, and less thorough version of the Instrumented test with the same name
   fun non_existing_uploadable_file_rejects_promise() {
     val irrelevantTaskId = UUID.randomUUID().toString()
@@ -765,6 +785,7 @@ class BlobCourierModuleTests {
     assertTrue(result.second, result.first)
   }
 
+  @Category(Isolated::class)
   @Test
   fun validating_non_null_values_works() {
     val someObject = Object()
@@ -785,6 +806,7 @@ class BlobCourierModuleTests {
     assertSame("Object doesn't match the provided object", someObject, rightObject.v)
   }
 
+  @Category(Isolated::class)
   @Test
   fun validating_not_null_or_empty_values_works() {
     val someObject = Object()

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -131,7 +131,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun all_required_fetch_parameters_provided_resolves_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -143,7 +143,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun unreachable_fetch_server_rejects_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
     val requestWithNonExistentUrl =
@@ -158,7 +158,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class, Slow::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun non_ok_http_fetch_response_resolves_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap()
     val requestWithNonExistentUrl =
@@ -175,7 +175,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun all_required_parameters_provided_resolves_upload_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -204,7 +204,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun using_a_string_payload_resolves_upload_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -245,7 +245,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun non_ok_http_response_resolves_upload_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 
@@ -276,7 +276,7 @@ class BlobCourierModuleTests {
   }
 
   @Category(EndToEnd::class, Slow::class)
-  @Test(timeout = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS)
+  @Test
   fun unreachable_server_rejects_upload_promise() = runBlocking {
     val allRequiredParametersMap = createValidTestFetchParameterMap().toReactMap()
 

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -12,11 +12,14 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReadableMap
 import io.deckers.blob_courier.Fixtures.createValidTestFetchParameterMap
 import io.deckers.blob_courier.Fixtures.createValidUploadTestParameterMap
 import io.deckers.blob_courier.Fixtures.runFetchBlobSuspend
 import io.deckers.blob_courier.Fixtures.runUploadBlobSuspend
+import io.deckers.blob_courier.TestUtils.assertRequestFalse
+import io.deckers.blob_courier.TestUtils.assertRequestTrue
+import io.deckers.blob_courier.TestUtils.runRequest
+import io.deckers.blob_courier.TestUtils.runRequestToBoolean
 import io.deckers.blob_courier.category.EndToEnd
 import io.deckers.blob_courier.category.Isolated
 import io.deckers.blob_courier.category.Regression
@@ -34,14 +37,11 @@ import io.deckers.blob_courier.upload.toMultipartBody
 import io.mockk.every
 import io.mockk.mockkStatic
 import java.util.UUID
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okhttp3.MediaType
 import okhttp3.MultipartBody
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -57,24 +57,6 @@ const val SOME_FILE_THAT_IS_ALWAYS_AVAILABLE = "file:///system/etc/fonts.xml"
 @Suppress("SameParameterValue")
 private fun <T : Any, V> assertTypeOf(message: String, o: T, t: Class<V>) =
   assertSame(message, o::class.java, t)
-
-private suspend fun runRequest(
-  block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
-  timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
-) =
-  withTimeout(timeoutMilliseconds, block)
-
-private suspend fun runRequestToBoolean(
-  block: suspend CoroutineScope.() -> Either<String, ReadableMap>,
-  timeoutMilliseconds: Long = DEFAULT_PROMISE_TIMEOUT_MILLISECONDS
-) =
-  runRequest(block, timeoutMilliseconds).fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-
-private fun assertRequestFalse(message: String, b: Boolean) =
-  assertFalse("Resolves, but expected reject: $message", b)
-
-private fun assertRequestTrue(message: String, b: Boolean) =
-  assertTrue("Rejects, but expected resolve: $message", b)
 
 private fun mapMultipartsToNames(parts: List<MultipartBody.Part>) =
   parts.fold(

--- a/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
+++ b/android/src/test/java/io/deckers/blob_courier/BlobCourierModuleTests.kt
@@ -139,10 +139,8 @@ class BlobCourierModuleTests {
 
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runFetchBlobSuspend(ctx, allRequiredParametersMap)
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runFetchBlobSuspend(ctx, allRequiredParametersMap)
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -157,10 +155,8 @@ class BlobCourierModuleTests {
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runFetchBlobSuspend(ctx, requestWithNonExistentUrl)
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runFetchBlobSuspend(ctx, requestWithNonExistentUrl)
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertFalse("Resolved, but expected reject: $message", succeeded)
   }
@@ -177,10 +173,8 @@ class BlobCourierModuleTests {
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runFetchBlobSuspend(ctx, requestWithNonExistentUrl)
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runFetchBlobSuspend(ctx, requestWithNonExistentUrl)
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -208,8 +202,8 @@ class BlobCourierModuleTests {
         runBlocking {
           runUploadBlobSuspend(ctx, uploadParametersMap)
         }
-      }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      }
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -249,8 +243,8 @@ class BlobCourierModuleTests {
         runBlocking {
           runUploadBlobSuspend(ctx, uploadParametersWithStringPayloadMap.toReactMap())
         }
-      }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      }
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -280,8 +274,8 @@ class BlobCourierModuleTests {
         runBlocking {
           runUploadBlobSuspend(ctx, uploadParametersMap.toReactMap())
         }
-      }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      }
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -311,8 +305,8 @@ class BlobCourierModuleTests {
         runBlocking {
           runUploadBlobSuspend(ctx, requestWithUnreachableUrl.toReactMap())
         }
-      }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      }
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertFalse("Resolved, but expected reject: $message", succeeded)
   }
@@ -367,10 +361,8 @@ class BlobCourierModuleTests {
       ).toReactMap()
 
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runUploadBlobSuspend(ctx, uploadParametersMap)
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runUploadBlobSuspend(ctx, uploadParametersMap)
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertTrue("Rejected, but expected resolve: $message", succeeded)
   }
@@ -394,10 +386,8 @@ class BlobCourierModuleTests {
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runFetchBlobSuspend(ctx, requestWithInvalidTargetDirectory)
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runFetchBlobSuspend(ctx, requestWithInvalidTargetDirectory)
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertFalse("Resolves, but expected reject: $message", succeeded)
   }
@@ -449,10 +439,8 @@ class BlobCourierModuleTests {
     val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
     val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-      val errorOrResult = runUploadBlobSuspend(ctx, allRequiredParametersMap.toReactMap())
-
-      errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-    }
+      runUploadBlobSuspend(ctx, allRequiredParametersMap.toReactMap())
+    }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
     assertFalse("Resolves, but expected reject: $message", succeeded)
   }
@@ -516,10 +504,8 @@ class BlobCourierModuleTests {
       val ctx = ReactApplicationContext(ApplicationProvider.getApplicationContext())
 
       val (succeeded, message) = withTimeout(DEFAULT_PROMISE_TIMEOUT_MILLISECONDS) {
-        val errorOrResult = runFetchBlobSuspend(ctx, requestWithInvalidTargetDirectory.toReactMap())
-
-        errorOrResult.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
-      }
+        runFetchBlobSuspend(ctx, requestWithInvalidTargetDirectory.toReactMap())
+      }.fold({ e -> Pair(false, e) }, { m -> Pair(true, "$m") })
 
       assertTrue("Rejected, but expected resolve: $message", succeeded)
     }

--- a/android/src/test/java/io/deckers/blob_courier/category/EndToEnd.kt
+++ b/android/src/test/java/io/deckers/blob_courier/category/EndToEnd.kt
@@ -1,0 +1,3 @@
+package io.deckers.blob_courier.category
+
+interface EndToEnd

--- a/android/src/test/java/io/deckers/blob_courier/category/Isolated.kt
+++ b/android/src/test/java/io/deckers/blob_courier/category/Isolated.kt
@@ -1,0 +1,3 @@
+package io.deckers.blob_courier.category
+
+interface Isolated

--- a/android/src/test/java/io/deckers/blob_courier/category/Regression.kt
+++ b/android/src/test/java/io/deckers/blob_courier/category/Regression.kt
@@ -1,0 +1,3 @@
+package io.deckers.blob_courier.category
+
+interface Regression

--- a/android/src/test/java/io/deckers/blob_courier/category/Slow.kt
+++ b/android/src/test/java/io/deckers/blob_courier/category/Slow.kt
@@ -1,0 +1,3 @@
+package io.deckers.blob_courier.category
+
+interface Slow

--- a/android/src/test/java/io/deckers/blob_courier/suite/CiSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/CiSuite.kt
@@ -1,0 +1,12 @@
+package io.deckers.blob_courier.suite
+
+import io.deckers.blob_courier.BlobCourierModuleTests
+import io.deckers.blob_courier.category.Slow
+import org.junit.experimental.categories.Categories
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Categories::class)
+@Categories.ExcludeCategory(Slow::class)
+@Suite.SuiteClasses(BlobCourierModuleTests::class)
+class CiSuite

--- a/android/src/test/java/io/deckers/blob_courier/suite/EndToEndSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/EndToEndSuite.kt
@@ -1,0 +1,11 @@
+package io.deckers.blob_courier.suite
+
+import io.deckers.blob_courier.BlobCourierModuleTests
+import org.junit.experimental.categories.Categories
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Categories::class)
+@Categories.IncludeCategory(EndToEndSuite::class)
+@Suite.SuiteClasses(BlobCourierModuleTests::class)
+class EndToEndSuite

--- a/android/src/test/java/io/deckers/blob_courier/suite/EndToEndSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/EndToEndSuite.kt
@@ -1,11 +1,12 @@
 package io.deckers.blob_courier.suite
 
 import io.deckers.blob_courier.BlobCourierModuleTests
+import io.deckers.blob_courier.category.EndToEnd
 import org.junit.experimental.categories.Categories
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
 @RunWith(Categories::class)
-@Categories.IncludeCategory(EndToEndSuite::class)
+@Categories.IncludeCategory(EndToEnd::class)
 @Suite.SuiteClasses(BlobCourierModuleTests::class)
 class EndToEndSuite

--- a/android/src/test/java/io/deckers/blob_courier/suite/EverythingSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/EverythingSuite.kt
@@ -1,0 +1,10 @@
+package io.deckers.blob_courier.suite
+
+import io.deckers.blob_courier.BlobCourierModuleTests
+import org.junit.experimental.categories.Categories
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Categories::class)
+@Suite.SuiteClasses(BlobCourierModuleTests::class)
+class EverythingSuite

--- a/android/src/test/java/io/deckers/blob_courier/suite/IsolatedSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/IsolatedSuite.kt
@@ -1,0 +1,12 @@
+package io.deckers.blob_courier.suite
+
+import io.deckers.blob_courier.BlobCourierModuleTests
+import io.deckers.blob_courier.category.Isolated
+import org.junit.experimental.categories.Categories
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Categories::class)
+@Categories.IncludeCategory(Isolated::class)
+@Suite.SuiteClasses(BlobCourierModuleTests::class)
+class IsolatedSuite

--- a/android/src/test/java/io/deckers/blob_courier/suite/SlowSuite.kt
+++ b/android/src/test/java/io/deckers/blob_courier/suite/SlowSuite.kt
@@ -1,0 +1,12 @@
+package io.deckers.blob_courier.suite
+
+import io.deckers.blob_courier.BlobCourierModuleTests
+import io.deckers.blob_courier.category.Slow
+import org.junit.experimental.categories.Categories
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Categories::class)
+@Categories.IncludeCategory(Slow::class)
+@Suite.SuiteClasses(BlobCourierModuleTests::class)
+class SlowSuite


### PR DESCRIPTION
# Progress
- [x] Add tests suites and categories
- [x] Migrate to coroutines
- [x] Fix broken assertion in `assert_missing_required_upload_parameter_rejects_promise`
- [x] Simplify re-used / boilerplate coroutine code
- [x] Simplify instrumented threaded tests
- [x] ~Use `kotlinx-coroutines` dependency only for testing~ actually replaced threading with coroutine
- [x] Add logging to Kotlin code
- [x] Make test settings configurable through environment variables
- [x] Only run CI test suite