### PR TITLE
refactor: use coroutine for test only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           script: |
             echo "ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS ${ORG_GRADLE_PROJECT_PROMISE_TIMEOUT_MILLISECONDS}"
             adb logcat -c
-            adb logcat | grep 'io.deckers.blob_courier' &
+            adb logcat | tee android_instrumented_logcat.log | grep 'io.deckers.blob_courier' &
             ./gradlew connectedAndroidTest
           target: google_apis
           working-directory: './android' 
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: android-instrumented-logcat
-          path: android_instrumented_logcat.log
+          path: android/android_instrumented_logcat.log
         if: always()
   run-ios-tests:
     needs: build-typescript

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If _CocoaPods_ is used in the project, make sure to install the pod:
 cd ios && pod install
 ```
 
+## Requirements
+
+- Android >= 19
+- iOS >= 7
+- Kotlin >= 1.4.x
+
 ## Usage
 
 The library provides both a fluent and a more concise interface. In the examples the concise approach is applied; fluent interface is demonstrated later in this document.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,8 +46,8 @@ android {
   packagingOptions {
     exclude 'androidsupportmultidexversion.txt'
     exclude 'META-INF/*.kotlin_module'
-    exclude 'META-INF/AL2.0'
-    exclude 'META-INF/LGPL2.1'
+    pickFirst 'META-INF/AL2.0'
+    pickFirst 'META-INF/LGPL2.1'
   }
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -154,7 +154,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation 'com.android.support:multidex:1.0.3'
   implementation "com.squareup.okhttp3:okhttp:3.14.9"
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
   testImplementation 'androidx.test:core:1.3.0'
   testImplementation 'junit:junit:4.13.1'
   testImplementation "io.mockk:mockk:1.10.2"
@@ -166,4 +165,5 @@ dependencies {
   androidTestImplementation "io.mockk:mockk-android:1.10.2"
   androidTestImplementation 'androidx.test.ext:junit:1.1.2'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,8 @@ android {
   packagingOptions {
     exclude 'androidsupportmultidexversion.txt'
     exclude 'META-INF/*.kotlin_module'
+    exclude 'META-INF/AL2.0'
+    exclude 'META-INF/LGPL2.1'
   }
 
 
@@ -161,9 +163,9 @@ dependencies {
   testImplementation "io.mockk:mockk-agent-jvm:1.10.2"
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
   testImplementation 'org.robolectric:robolectric:4.4'
-  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
   androidTestImplementation "io.mockk:mockk-android:1.10.2"
   androidTestImplementation 'androidx.test.ext:junit:1.1.2'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
 }

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -56,6 +56,11 @@ private suspend fun waitForDisabledNetwork() =
           li("Line contains 'unknown'; network is disabled")
           return@withContext
         }
+
+        if (line?.contains("unreachable") == true) {
+          li("Line contains 'unreachable'; network is disabled")
+          return@withContext
+        }
       }
 
       if (!p.isAlive && p.exitValue() == 2) {


### PR DESCRIPTION
Should 'fix' (it is not really a `react-native-blob-courier` issue but rather a dependency clash in the project that uses the library)  #106. Nevertheless _fewer dependencies is more better_, so let's get rid of it.

# Progress
- [x] Use `coroutines` dependency in `testImplementation` and `androidTestImplementation`; remove it from `implementation`
- [x] Bump dependency to 1.4.2
- [x] Add requirement for Kotlin 4.x+ to `README.md`
- [x] Create 'common pitfalls' topic in Wiki (https://github.com/edeckers/react-native-blob-courier/wiki/Common-pitfalls) and describe how to fix dependency clashes (see https://github.com/edeckers/react-native-blob-courier/issues/106#issuecomment-754177936)