### PR TITLE
chore: use self-hosted runner for MacOs actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
   run-android-instrumented-tests:
     continue-on-error: true
     needs: build-typescript
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps: 
       - uses: actions/checkout@v2
       - name: set up JDK 1.8
@@ -79,10 +79,10 @@ jobs:
         if: always()
   run-ios-tests:
     needs: build-typescript
-    runs-on: macos-latest
+    runs-on: self-hosted
     steps: 
       - uses: actions/checkout@v2
-      - run: xcrun simctl boot "iPhone 11"
+      - run: xcrun simctl boot "iPhone 11" || true
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '12'


### PR DESCRIPTION
A lot of times the instrumented Android tests seem to fail for no good reason at all, so let's migrate to a self hosted runner, since I have one available anyway.