### PR TITLE
Fix progress interval setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd ios && pod install
 
 ## Requirements
 
-- Android >= 19
+- Android >= 21
 - iOS >= 10
 - Kotlin >= 1.4.x
 
@@ -496,7 +496,7 @@ You can find an example of how to use the library in the [example](example) dire
 
 ### Permissions
 
-### Android 5.0 and below (API level < 23)
+### Android 5.1 and below (API level < 23)
 
 Add the following line to `AndroidManifest.xml`.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 [![Build](https://github.com/edeckers/react-native-blob-courier/workflows/Build%20Android%20and%20iOS/badge.svg)](https://github.com/edeckers/react-native-blob-courier/actions)
 
-Use this library to efficiently _download_ and _upload_ blobs in React Native. The library was inspired by [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob), and aims to focus strictly on blob transfers.
+Use this library to efficiently download and upload data in React Native. The library was inspired by [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob), and is focused strictly on http file transfers.
 
 ## Installation
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -149,6 +149,7 @@ repositories {
 }
 
 def kotlin_version = getExtOrDefault('kotlinVersion')
+def mockk_version = '1.12.1'
 
 dependencies {
   // noinspection GradleDynamicVersion
@@ -159,13 +160,13 @@ dependencies {
   implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
   testImplementation 'androidx.test:core:1.3.0'
   testImplementation 'junit:junit:4.13.1'
-  testImplementation "io.mockk:mockk:1.10.2"
-  testImplementation "io.mockk:mockk-agent-api:1.10.2"
-  testImplementation "io.mockk:mockk-agent-jvm:1.10.2"
+  testImplementation "io.mockk:mockk:$mockk_version"
+  testImplementation "io.mockk:mockk-agent-api:$mockk_version"
+  testImplementation "io.mockk:mockk-agent-jvm:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
   testImplementation 'org.robolectric:robolectric:4.4'
   testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"
-  androidTestImplementation "io.mockk:mockk-android:1.10.2"
+  androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation 'androidx.test.ext:junit:1.1.2'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,8 +1,8 @@
 BlobCourier_kotlinVersion = 1.4.21
 BlobCourier_compileSdkVersion = 30
 BlobCourier_buildToolsVersion = 30.0.0
-BlobCourier_targetSdkVersion = 29
-BlobCourier_minSdkVersion = 19
+BlobCourier_targetSdkVersion = 30
+BlobCourier_minSdkVersion = 21
 
 ADB_COMMAND_TIMEOUT_MILLISECONDS = 10000L
 PROMISE_TIMEOUT_MILLISECONDS = 60000L

--- a/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
+++ b/android/src/androidTest/java/io/deckers/blob_courier/BlobCourierInstrumentedModuleTests.kt
@@ -23,7 +23,6 @@ import io.deckers.blob_courier.Fixtures.runFetchBlobSuspend
 import io.deckers.blob_courier.TestUtils
 import io.deckers.blob_courier.TestUtils.assertRequestFalse
 import io.deckers.blob_courier.TestUtils.assertRequestTrue
-import io.deckers.blob_courier.TestUtils.circumventHiddenApiExemptionsForMockk
 import io.deckers.blob_courier.TestUtils.runInstrumentedRequestToBoolean
 import io.deckers.blob_courier.common.DOWNLOAD_TYPE_MANAGED
 import io.deckers.blob_courier.common.ERROR_CANCELED_EXCEPTION
@@ -147,8 +146,6 @@ class BlobCourierInstrumentedModuleTests {
   @Before
   fun mockSomeNativeOnlyMethods() {
     li("Restore method mocks")
-
-    circumventHiddenApiExemptionsForMockk()
 
     mockkStatic(Arguments::class)
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.deckers.blob_courier"
-    xmlns:tools="http://schemas.android.com/tools">
+  xmlns:tools="http://schemas.android.com/tools"
+  package="io.deckers.blob_courier">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
   <uses-sdk tools:overrideLibrary="com.facebook.react" />
 
-  <application android:usesCleartextTraffic="true" />
+  <application
+    android:usesCleartextTraffic="true"
+    tools:targetApi="m" />
 
 </manifest>

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -22,11 +22,9 @@ import io.deckers.blob_courier.common.ERROR_UNKNOWN_HOST
 import io.deckers.blob_courier.common.Failure
 import io.deckers.blob_courier.common.LIBRARY_NAME
 import io.deckers.blob_courier.common.Logger
-import io.deckers.blob_courier.common.PARAMETER_SETTINGS_PROGRESS_INTERVAL
 import io.deckers.blob_courier.common.Success
 import io.deckers.blob_courier.common.`do`
 import io.deckers.blob_courier.common.fold
-import io.deckers.blob_courier.common.getMapInt
 import io.deckers.blob_courier.fetch.BlobDownloader
 import io.deckers.blob_courier.fetch.DownloaderParameterFactory
 import io.deckers.blob_courier.react.CongestionAvoidingProgressNotifierFactory
@@ -59,12 +57,6 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext) {
 
   override fun getName(): String = LIBRARY_NAME
-
-  private fun getProgressInterval(input: ReadableMap) = getMapInt(
-    input,
-    PARAMETER_SETTINGS_PROGRESS_INTERVAL,
-    DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS
-  )
 
   @ReactMethod
   fun cancelRequest(input: ReadableMap, promise: Promise) {

--- a/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
+++ b/android/src/main/java/io/deckers/blob_courier/BlobCourierModule.kt
@@ -59,6 +59,11 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
 
   override fun getName(): String = LIBRARY_NAME
 
+  private fun getProgressInterval(input: ReadableMap) =
+    if (input.hasKey(PARAMETER_SETTINGS_PROGRESS_INTERVAL)) input.getInt(
+      PARAMETER_SETTINGS_PROGRESS_INTERVAL
+    ) else DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS
+
   @ReactMethod
   fun cancelRequest(input: ReadableMap, promise: Promise) {
     li("Calling cancelRequest")
@@ -106,9 +111,8 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
                 reactContext,
                 createHttpClient(),
                 createProgressFactory(
-                  reactContext, input.getInt(
-                    PARAMETER_SETTINGS_PROGRESS_INTERVAL
-                  )
+                  reactContext,
+                  getProgressInterval(input)
                 ),
               )::download
             )
@@ -149,9 +153,8 @@ class BlobCourierModule(private val reactContext: ReactApplicationContext) :
               reactContext,
               createHttpClient(),
               createProgressFactory(
-                reactContext, input.getInt(
-                  PARAMETER_SETTINGS_PROGRESS_INTERVAL
-                )
+                reactContext,
+                getProgressInterval(input)
               )
             )::upload
           )

--- a/android/src/main/java/io/deckers/blob_courier/fetch/DownloaderParameterFactory.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/DownloaderParameterFactory.kt
@@ -31,7 +31,6 @@ import io.deckers.blob_courier.common.isNotNull
 import io.deckers.blob_courier.common.maybe
 import io.deckers.blob_courier.common.testKeep
 import io.deckers.blob_courier.common.validationContext
-import java.util.Locale
 
 private const val PARAMETER_ANDROID_SETTINGS = "android"
 private const val PARAMETER_DOWNLOAD_MANAGER_SETTINGS = "downloadManager"
@@ -91,8 +90,7 @@ private fun validateParameters(
     BlobDownloader.TargetDirectoryEnum
       .values()
       .firstOrNull { t ->
-        t.name.toLowerCase(Locale.getDefault()) ==
-          targetDirectoryOrFallback.toLowerCase(Locale.getDefault())
+        t.name.equals(targetDirectoryOrFallback, ignoreCase = true)
       }
 
   val downloadManagerSettings =

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloadReceiver.kt
@@ -87,8 +87,13 @@ class ManagedDownloadReceiver(
     lv("Received status (status=$status, isStatusSuccessful=$isStatusSuccessful)")
 
     if (isStatusSuccessful) {
-      val localFileUri =
-        Uri.parse(cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)))
+      val columnLocalUri = cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
+      val isExistingColumn = columnLocalUri > 0
+      if (!isExistingColumn) {
+        return
+      }
+
+      val localFileUri = Uri.parse(cursor.getString(columnLocalUri))
 
       onDownloadDone(context, localFileUri)
 

--- a/android/src/main/java/io/deckers/blob_courier/progress/ManagedProgressUpdater.kt
+++ b/android/src/main/java/io/deckers/blob_courier/progress/ManagedProgressUpdater.kt
@@ -54,10 +54,17 @@ class ManagedProgressUpdater(
           return
         }
 
-        val numberOfBytes =
-          cursor.getLong(cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
-        val totalSizeBytes =
-          cursor.getLong(cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES))
+        val columnBytesDownloadedSoFar =
+          cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+        val columnTotalSizeBytes = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
+
+        val areExistingColumns = columnBytesDownloadedSoFar > 0 && columnTotalSizeBytes > 0
+        if (!areExistingColumns) {
+          return
+        }
+
+        val numberOfBytes = cursor.getLong(columnBytesDownloadedSoFar)
+        val totalSizeBytes = cursor.getLong(columnTotalSizeBytes)
 
         progressNotifier.notify(numberOfBytes, totalSizeBytes)
       }

--- a/android/src/main/java/io/deckers/blob_courier/react/Utils.kt
+++ b/android/src/main/java/io/deckers/blob_courier/react/Utils.kt
@@ -70,6 +70,8 @@ fun Map<*, *>.toReactMap(): WritableMap {
         (v is Boolean) -> {
           putBoolean(k.toString(), v)
         }
+        (v is Int) ->
+          putInt(k.toString(), v)
         (v is String) ->
           putString(k.toString(), v)
         (v is Map<*, *>) -> {

--- a/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
@@ -110,7 +110,7 @@ private fun filterReadableMapsFromReadableArray(parts: ReadableArray): Array<Rea
     emptyArray(),
     { p, i ->
       if (parts.getType(i) == ReadableType.Map)
-        p.plus(parts.getMap(i)!!)
+        p.plus(parts.getMap(i))
       else p
     }
   )

--- a/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/Fixtures.kt
@@ -19,12 +19,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import java.io.File
 import java.io.RandomAccessFile
+import java.io.Serializable
 
 object Fixtures {
 
   const val LARGE_FILE = "http://ipv4.download.thinkbroadband.com/100MB.zip"
 
-  fun createValidTestFetchParameterMap(): Map<String, String> = mapOf(
+  fun createValidTestFetchParameterMap(): Map<String, Serializable> = mapOf(
     "taskId" to "some-task-id",
     "filename" to "some-filename.png",
     "url" to "https://github.com/edeckers/react-native-blob-courier"

--- a/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
+++ b/android/src/sharedTest/java/io/deckers/blob_courier/TestUtils.kt
@@ -6,52 +6,15 @@
  */
 package io.deckers.blob_courier
 
-import android.os.Build
 import com.facebook.react.bridge.ReadableMap
 import io.deckers.blob_courier.BuildConfig.PROMISE_TIMEOUT_MILLISECONDS
 import io.deckers.blob_courier.common.Either
 import io.deckers.blob_courier.common.fold
-import java.lang.reflect.Method
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert
 
 object TestUtils {
-  private const val vmRuntimeClassName = "dalvik.system.VMRuntime"
-  private const val getDeclaredMethodMethodName = "getDeclaredMethod"
-  private const val getRuntimeMethodName = "getRuntime"
-  private const val setHiddenApiExemptionsMethodName = "setHiddenApiExemptions"
-
-  fun circumventHiddenApiExemptionsForMockk() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-      return
-    }
-
-    // https://github.com/mockk/mockk/pull/442
-    try {
-      val vmRuntimeClass = Class.forName(vmRuntimeClassName)
-      val getDeclaredMethod = Class::class.java.getDeclaredMethod(
-        getDeclaredMethodMethodName,
-        String::class.java,
-        arrayOf<Class<*>>()::class.java
-      ) as Method
-      val getRuntime = getDeclaredMethod(
-        vmRuntimeClass,
-        getRuntimeMethodName,
-        null
-      ) as Method
-      val setHiddenApiExemptions = getDeclaredMethod(
-        vmRuntimeClass,
-        setHiddenApiExemptionsMethodName,
-        arrayOf(arrayOf<String>()::class.java)
-      ) as Method
-
-      setHiddenApiExemptions(getRuntime(null), arrayOf("L"))
-    } catch (ex: Exception) {
-      throw Exception("Could not set up hiddenApiExemptions")
-    }
-  }
-
   suspend fun runRequest(
     block: suspend CoroutineScope.() -> Either<Fixtures.TestPromiseError, ReadableMap>,
     timeoutMilliseconds: Long = PROMISE_TIMEOUT_MILLISECONDS


### PR DESCRIPTION
The progress interval parameter wasn't passed to the `CongestionAvoidingProgressNotifierFactory` on Android, and instead the default value `DEFAULT_PROGRESS_TIMEOUT_MILLISECONDS` was used.

- [x] Pass progress interval parameter to `CongestionAvoidingProgressNotifierFactory`
- [x] Add tests