### PR TITLE
Fix UploaderParameterFactory type mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,12 @@ Or install using _npm_
 npm install react-native-blob-courier
 ```
 
-Link the library:
-
-NB. Linking can be skipped when the project uses React Native 0.60 or greater, because [autolinking](https://reactnative.dev/blog/2019/07/03/version-60#native-modules-are-now-autolinked) will take care of it
-
-```sh
-react-native link react-native-blob-courier
-```
-
-If _CocoaPods_ is used in the project, make sure to install the pod:
-
-```sh
-cd ios && pod install
-```
-
 ## Requirements
 
 - Android >= 21
 - iOS >= 10
 - Kotlin >= 1.4.x
+- React Native >= 0.63.x
 
 ## Usage
 

--- a/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
@@ -110,7 +110,7 @@ private fun filterReadableMapsFromReadableArray(parts: ReadableArray): Array<Rea
     emptyArray(),
     { p, i ->
       if (parts.getType(i) == ReadableType.Map)
-        p.plus(parts.getMap(i))
+        p.plus(parts.getMap(i)!!)
       else p
     }
   )

--- a/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
+++ b/android/src/main/java/io/deckers/blob_courier/upload/UploaderParameterFactory.kt
@@ -110,6 +110,14 @@ private fun filterReadableMapsFromReadableArray(parts: ReadableArray): Array<Rea
     emptyArray(),
     { p, i ->
       if (parts.getType(i) == ReadableType.Map)
+        // Added linter suppression because from RN0.63 -> RN0.64 the interface changes from
+        // @Nullable to @NonNullable, see:
+        // https://github.com/edeckers/react-native-blob-courier/issues/180
+        //
+        // A better solution would probably be to pin the RN version, but that isn't as
+        // straight-forward as just pinning a particular Gradle dependency:
+        // https://github.com/facebook/react-native/issues/13094#issuecomment-288616901
+        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
         p.plus(parts.getMap(i)!!)
       else p
     }


### PR DESCRIPTION
When not using this fix, Android build on `RN 0.63` fails with: `Type mismatch: inferred type is ReadableMap? but TypeVariable(T) was expected`

- [x] Fix syntax error
- [x] Suppress linter warning
- [x] Add comment that links to #180 and explains situation
- [x] Add `RN >= 0.63` requirement to README.md
- [x] Remove `RN < 0.63` mentions and caveats from README.md