### PR TITLE
feat: bump minSdkVersion from 21 to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install react-native-blob-courier
 
 ## Requirements
 
-- Android >= 21
+- Android >= 24
 - Android Gradle Plugin >= 7
 - iOS >= 10
 - JDK >= 11

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,7 +14,7 @@ BlobCourier_testLoggerVersion = 2.1.1
 
 BlobCourier_buildToolsVersion = 30.0.2
 BlobCourier_compileSdkVersion = 31
-BlobCourier_minSdkVersion = 21
+BlobCourier_minSdkVersion = 24
 BlobCourier_targetSdkVersion = 30
 
 ADB_COMMAND_TIMEOUT_MILLISECONDS = 10000L


### PR DESCRIPTION
Library doesn't compile on pre 24 sdk, as reported by the `gradlew lint`:
https://github.com/edeckers/react-native-blob-courier/runs/7561248035?check_suite_focus=true#step:5:214

Releasing it as a feature instead of a breaking change though, because it has always been broken, so noone should be affected.