### PR TITLE
Android - RN .73.6 - Incompatibility between JVM settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,13 +75,6 @@ android {
   lintOptions {
     disable 'GradleCompatible'
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
-  }
 }
 
 repositories {


### PR DESCRIPTION
Hi! 

This pull request aims to fix the following [issue](https://github.com/edeckers/react-native-blob-courier/issues/257).
At this time, both [compilation](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html) and [kotlin](https://kotlinlang.org/docs/gradle-compiler-options.html#target-the-jvm) options are hardcoded to JDK 11, making this project unable to run with React Native versions above .73 due to a conflict between the target JVM.
From version .73, React Native supports Android 14 ([Blog](https://reactnative.dev/blog/2023/12/06/0.73-debugging-improvements-stable-symlinks)) and in doing so it compiles with JDK 17, so its compileOptions collide with this library ones.

I've looked into other kotlin libraries, mostly react-native-webview's [build.gradle](https://github.com/react-native-webview/react-native-webview/blob/master/android/build.gradle) and I've seen that they avoid to set compileOptions and kotlinOptions directly.

When we don't set both of them in our library's build.gradle, the Gradle Plugin automatically leverages the project's settings or the Android Studio default ones.

Thank you for this awesome library!

Cheers! 🍻