### PR TITLE
Android 14 - Missing RECEIVER_EXPORTED / RECEIVER_NOT_EXPORTED flag

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,9 +14,9 @@ BlobCourier_testExtVersion = 1.1.+
 BlobCourier_testLoggerVersion = 2.1.1
 
 BlobCourier_buildToolsVersion = 30.0.2
-BlobCourier_compileSdkVersion = 31
+BlobCourier_compileSdkVersion = 34
 BlobCourier_minSdkVersion = 24
-BlobCourier_targetSdkVersion = 30
+BlobCourier_targetSdkVersion = 34
 
 ADB_COMMAND_TIMEOUT_MILLISECONDS = 10000L
 PROMISE_TIMEOUT_MILLISECONDS = 60000L

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
@@ -167,7 +167,7 @@ class ManagedDownloader(
       context.registerReceiver(
         downloadReceiver,
         IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-        Context.RECEIVER_NOT_EXPORTED
+        Context.RECEIVER_EXPORTED
       )
     } else {
       @Suppress("UnspecifiedRegisterReceiverFlag")

--- a/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
+++ b/android/src/main/java/io/deckers/blob_courier/fetch/ManagedDownloader.kt
@@ -11,6 +11,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import io.deckers.blob_courier.common.ACTION_CANCEL_REQUEST
 import io.deckers.blob_courier.common.BlobCourierError
@@ -162,10 +163,19 @@ class ManagedDownloader(
   private fun registerDownloadCompletionHandler(downloadReceiver: ManagedDownloadReceiver) {
     lv("Registering ${DownloadManager.ACTION_DOWNLOAD_COMPLETE} receiver")
 
-    context.registerReceiver(
-      downloadReceiver,
-      IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-    )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(
+        downloadReceiver,
+        IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+        Context.RECEIVER_NOT_EXPORTED
+      )
+    } else {
+      @Suppress("UnspecifiedRegisterReceiverFlag")
+      context.registerReceiver(
+        downloadReceiver,
+        IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+      )
+    }
 
     lv("Registered ${DownloadManager.ACTION_DOWNLOAD_COMPLETE} receiver")
   }


### PR DESCRIPTION
Hi!

This pull request aims to fix the following [issue](https://github.com/edeckers/react-native-blob-courier/issues/256).
When we try to run fetchBlob method with managed download turned on in a device with Android 14, a SecurityException is thrown.

RECEIVER_NOT_EXPORTED is the preferred choice when we don't need other apps to use our receiver, in doing so it strengthens security. Therefore I've set it to this flag.

Cheers! 🍻